### PR TITLE
Disable sleep while playing an audio

### DIFF
--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/AudioPlayActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/AudioPlayActivity.java
@@ -413,7 +413,7 @@ public class AudioPlayActivity extends CacheWordSubscriberBaseActivity implement
 
         paused = false;
         disablePlay();
-        disableSleep();
+        disableScreenTimeout();
     }
 
     private void handlePause() {
@@ -427,7 +427,7 @@ public class AudioPlayActivity extends CacheWordSubscriberBaseActivity implement
         if (audioPlayer != null) {
             audioPlayer.pause();
         }
-        enableSleep();
+        enableScreenTimeout();
     }
 
     private void onPlayerStop() {
@@ -461,7 +461,7 @@ public class AudioPlayActivity extends CacheWordSubscriberBaseActivity implement
             audioPlayer.stop();
             audioPlayer = null;
             onPlayerStop();
-            enableSleep();
+            enableScreenTimeout();
         }
     }
 
@@ -487,11 +487,11 @@ public class AudioPlayActivity extends CacheWordSubscriberBaseActivity implement
                         TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(duration)));
     }
 
-    private void disableSleep(){
+    private void disableScreenTimeout() {
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 
-    private void enableSleep(){
+    private void enableScreenTimeout() {
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 }

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/AudioPlayActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/AudioPlayActivity.java
@@ -461,6 +461,7 @@ public class AudioPlayActivity extends CacheWordSubscriberBaseActivity implement
             audioPlayer.stop();
             audioPlayer = null;
             onPlayerStop();
+            enableSleep();
         }
     }
 

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/AudioPlayActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/AudioPlayActivity.java
@@ -15,6 +15,7 @@ import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.ImageButton;
 import android.widget.TextView;
 
@@ -412,6 +413,7 @@ public class AudioPlayActivity extends CacheWordSubscriberBaseActivity implement
 
         paused = false;
         disablePlay();
+        disableSleep();
     }
 
     private void handlePause() {
@@ -425,6 +427,7 @@ public class AudioPlayActivity extends CacheWordSubscriberBaseActivity implement
         if (audioPlayer != null) {
             audioPlayer.pause();
         }
+        enableSleep();
     }
 
     private void onPlayerStop() {
@@ -481,5 +484,13 @@ public class AudioPlayActivity extends CacheWordSubscriberBaseActivity implement
                         TimeUnit.MINUTES.toMinutes(TimeUnit.MILLISECONDS.toHours(duration)),
                 TimeUnit.MILLISECONDS.toSeconds(duration) -
                         TimeUnit.MINUTES.toSeconds(TimeUnit.MILLISECONDS.toMinutes(duration)));
+    }
+
+    private void disableSleep(){
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    }
+
+    private void enableSleep(){
+        getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
     }
 }


### PR DESCRIPTION
Screen timeout (sleep) should be disabled while playing an audio file, and re-enabled when playing is paused or stops.