### PR TITLE
Replace Fabric with Firebase Crashlytics.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,9 +15,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
-
-        classpath 'io.fabric.tools:gradle:1.31.2'
         classpath 'com.google.gms:google-services:4.3.3'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
     }
 }
 

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,26 +1,26 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.crashlytics'
 
 ext {
     supportLibVersion = "28.0.3"
     retrofitVersion = '2.6.1'
-    permissionDispatcherVersion = "4.5.0"
+    permissionDispatcherVersion = "4.8.0"
     googlePlayServicesVersion = "17.0.0"
-    leakCanaryVersion = '1.6.3'
+    leakCanaryVersion = '2.4'
     butterknifeVersion = '10.1.0'
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "org.hzontal.tella"
         minSdkVersion 17
         compileSdkVersion 28
-        targetSdkVersion 28
-        versionCode 52
-        versionName "1.6.2"
+        targetSdkVersion 29
+        versionCode 59
+        versionName "1.7.0"
         multiDexEnabled true
         // vectorDrawables.useSupportLibrary = true // don't care about apk size, care about crashes
     }
@@ -55,22 +55,22 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     // implementation 'com.madgag.spongycastle:pg:1.54.0.0'// needed for above
 
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    implementation platform('com.google.firebase:firebase-bom:26.1.0')
+    implementation 'com.google.firebase:firebase-crashlytics'
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'androidx.exifinterface:exifinterface:1.0.0'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.0'
     implementation "com.google.android.gms:play-services-location:${googlePlayServicesVersion}"
     implementation "com.google.android.gms:play-services-maps:${googlePlayServicesVersion}"
     // implementation "com.google.android.gms:play-services-gcm:${googlePlayServicesVersion}" // android-job, optional
-    // implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
     implementation "com.squareup.retrofit2:retrofit:${retrofitVersion}"
     implementation "com.squareup.retrofit2:adapter-rxjava2:${retrofitVersion}"
@@ -84,7 +84,6 @@ dependencies {
     implementation("org.permissionsdispatcher:permissionsdispatcher:${permissionDispatcherVersion}") {
         exclude module: "support-v13"
     }
-
     annotationProcessor "org.permissionsdispatcher:permissionsdispatcher-processor:${permissionDispatcherVersion}"
 
     implementation 'com.squareup.okhttp3:logging-interceptor:3.6.0'
@@ -92,11 +91,11 @@ dependencies {
     implementation "com.jakewharton.timber:timber:4.7.1"
     implementation 'net.zetetic:android-database-sqlcipher:3.5.7@aar'
     implementation 'info.guardianproject.cacheword:cachewordlib:0.1.1'
-    implementation 'com.github.bumptech.glide:glide:3.7.0' //implementation 'com.github.bumptech.glide:glide:4.9.0'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
     implementation 'me.zhanghai.android.patternlock:library:2.1.2'
-    implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
-    implementation 'io.reactivex.rxjava2:rxjava:2.2.2'
-    implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.0'
+    implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
+    implementation 'com.jakewharton.rxrelay2:rxrelay:2.1.1'
     implementation 'com.evernote:android-job:1.3.0-rc1'
 
     implementation "com.jakewharton:butterknife:${butterknifeVersion}"
@@ -120,19 +119,13 @@ dependencies {
     }
 
     implementation 'com.github.apl-devs:appintro:v4.2.3'
-
     implementation 'com.simplify:ink:1.0.2'
-
     implementation 'com.mikhaellopez:circularimageview:3.2.0'
-
-    debugImplementation "com.squareup.leakcanary:leakcanary-android:${leakCanaryVersion}"
-    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${leakCanaryVersion}"
-    debugImplementation "com.squareup.leakcanary:leakcanary-support-fragment:${leakCanaryVersion}"
-
-    testImplementation 'junit:junit:4.13-beta-3'
-
-    implementation 'org.apache.directory.studio:org.apache.commons.io:2.4'//import com.google.android.gms.common.util.IOUtils;
-
+    implementation 'org.apache.directory.studio:org.apache.commons.io:2.4'
     implementation 'io.github.luizgrp.sectionedrecyclerviewadapter:sectionedrecyclerviewadapter:3.2.0'
     implementation 'com.github.lzyzsd:circleprogress:1.2.1'
+
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:${leakCanaryVersion}"
+
+    testImplementation 'junit:junit:4.13'
 }

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -59,10 +59,6 @@
             </intent-filter>
         </receiver> -->
 
-        <meta-data
-            android:name="io.fabric.ApiKey"
-            android:value="96357564e9129c887ba59fb3e0957fcc10c76115" />
-
         <activity
             android:name=".views.activity.SplashActivity"
             android:icon="@mipmap/tella_icon_round"

--- a/mobile/src/main/java/rs/readahead/washington/mobile/data/provider/EncryptedFileProvider.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/data/provider/EncryptedFileProvider.java
@@ -117,7 +117,7 @@ public class EncryptedFileProvider extends FileProvider {
                 out.flush();
             } catch(IOException e) {
                 Timber.e(e, getClass().getSimpleName());
-                //Crashlytics.logException(e);
+                //FirebaseCrashlytics.getInstance().recordException(e);
             } finally {
                 try {
                     if (cipherInputStream != null) cipherInputStream.close();
@@ -206,7 +206,7 @@ public class EncryptedFileProvider extends FileProvider {
                 }
             } catch(IOException e) {
                 Timber.e(e, getClass().getSimpleName());
-                //Crashlytics.logException(e);
+                //FirebaseCrashlytics.getInstance().recordException(e);
             } finally {
                 try {
                     in.close();

--- a/mobile/src/main/java/rs/readahead/washington/mobile/javarosa/FormParser.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/javarosa/FormParser.java
@@ -1,10 +1,8 @@
 package rs.readahead.washington.mobile.javarosa;
 
-import androidx.annotation.NonNull;
-
 import android.text.TextUtils;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.javarosa.core.model.Constants;
 import org.javarosa.core.model.FormIndex;
@@ -12,6 +10,7 @@ import org.javarosa.form.api.FormEntryCaption;
 import org.javarosa.form.api.FormEntryController;
 import org.javarosa.form.api.FormEntryPrompt;
 
+import androidx.annotation.NonNull;
 import rs.readahead.washington.mobile.R;
 import rs.readahead.washington.mobile.domain.entity.MediaFile;
 import rs.readahead.washington.mobile.domain.entity.Metadata;
@@ -241,7 +240,7 @@ public class FormParser implements IFormParserContract.IFormParser {
     }
 
     private void viewFormParseError(Throwable throwable) {
-        Crashlytics.logException(throwable);
+        FirebaseCrashlytics.getInstance().recordException(throwable);
         view.formParseError(throwable);
     }
 

--- a/mobile/src/main/java/rs/readahead/washington/mobile/javarosa/FormReSubmitter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/javarosa/FormReSubmitter.java
@@ -2,7 +2,7 @@ package rs.readahead.washington.mobile.javarosa;
 
 import android.content.Context;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -90,7 +90,7 @@ public class FormReSubmitter implements IFormReSubmitterContract.IFormReSubmitte
                                 // PendingFormSendJob.scheduleJob();
                                 view.formReSubmitNoConnectivity();
                             } else {
-                                Crashlytics.logException(throwable);
+                                FirebaseCrashlytics.getInstance().recordException(throwable);
                                 view.formPartReSubmitError(throwable);
                             }
                         },

--- a/mobile/src/main/java/rs/readahead/washington/mobile/javarosa/FormSubmitter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/javarosa/FormSubmitter.java
@@ -1,14 +1,14 @@
 package rs.readahead.washington.mobile.javarosa;
 
 import android.content.Context;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.Nullable;
 import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
 import io.reactivex.Single;
@@ -30,7 +30,6 @@ import rs.readahead.washington.mobile.domain.entity.collect.FormMediaFile;
 import rs.readahead.washington.mobile.domain.entity.collect.FormMediaFileStatus;
 import rs.readahead.washington.mobile.domain.entity.collect.NegotiatedCollectServer;
 import rs.readahead.washington.mobile.domain.entity.collect.OpenRosaPartResponse;
-import rs.readahead.washington.mobile.domain.entity.collect.OpenRosaResponse;
 import rs.readahead.washington.mobile.domain.exception.NoConnectivityException;
 import rs.readahead.washington.mobile.domain.repository.IOpenRosaRepository;
 import rs.readahead.washington.mobile.odk.FormController;
@@ -105,7 +104,7 @@ public class FormSubmitter implements IFormSubmitterContract.IFormSubmitter {
                         // PendingFormSendJob.scheduleJob();
                         view.formSubmitNoConnectivity();
                     } else {
-                        Crashlytics.logException(throwable);
+                        FirebaseCrashlytics.getInstance().recordException(throwable);
                         view.formSubmitError(throwable);
                     }
                 })
@@ -153,7 +152,7 @@ public class FormSubmitter implements IFormSubmitterContract.IFormSubmitter {
                                 // PendingFormSendJob.scheduleJob();
                                 view.formSubmitNoConnectivity();
                             } else {
-                                Crashlytics.logException(throwable);
+                                FirebaseCrashlytics.getInstance().recordException(throwable);
                                 view.formPartSubmitError(throwable);
                             }
                         },

--- a/mobile/src/main/java/rs/readahead/washington/mobile/media/MediaFileHandler.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/media/MediaFileHandler.java
@@ -16,7 +16,7 @@ import android.os.Environment;
 import android.text.TextUtils;
 import android.widget.Toast;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.apache.commons.io.IOUtils;
 
@@ -92,7 +92,7 @@ public class MediaFileHandler {
             return FileUtil.mkdirs(tmpPath) && ret;
         } catch (Exception e) {
             Timber.e(e);
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             return false;
         }
     }
@@ -188,7 +188,7 @@ public class MediaFileHandler {
 
             MediaScannerConnection.scanFile(context, new String[]{file.toString()}, null, null);
         } catch (IOException e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             throw e;
         } finally {
             FileUtil.close(is);
@@ -306,7 +306,7 @@ public class MediaFileHandler {
                 mediaFileBundle.setMediaFileThumbnailData(new MediaFileThumbnailData(thumb));
             }
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             Timber.e(e, MediaFileHandler.class.getName());
         } finally {
             try {
@@ -359,7 +359,7 @@ public class MediaFileHandler {
             mediaFile.setHash(StringUtils.hexString(os.getMessageDigest().digest()));
             mediaFile.setSize(getSize(context, mediaFile));
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             Timber.e(e, MediaFileHandler.class.getName());
         } finally {
             FileUtil.close(vis);
@@ -391,7 +391,7 @@ public class MediaFileHandler {
                 return new MediaFileThumbnailData(thumb);
             }
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             Timber.e(e, MediaFileHandler.class.getName());
         } finally {
             FileUtil.close(vis);

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/AttachmentsPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/AttachmentsPresenter.java
@@ -3,7 +3,7 @@ package rs.readahead.washington.mobile.mvp.presenter;
 
 import android.net.Uri;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -101,7 +101,7 @@ public class AttachmentsPresenter implements IAttachmentsPresenterContract.IPres
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onImportEnded())
                 .subscribe(mediaHolder -> view.onEvidenceImported(mediaHolder), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onImportError(throwable);
                 })
         );
@@ -116,7 +116,7 @@ public class AttachmentsPresenter implements IAttachmentsPresenterContract.IPres
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onImportEnded())
                 .subscribe(mediaHolder -> view.onEvidenceImported(mediaHolder), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onImportError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/AudioCapturePresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/AudioCapturePresenter.java
@@ -4,7 +4,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.os.StatFs;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -38,7 +38,7 @@ public class AudioCapturePresenter implements IAudioCapturePresenterContract.IPr
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onAddingEnd())
                 .subscribe(mediaFile1 -> view.onAddSuccess(mediaFile1), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onAddError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CameraPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CameraPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.io.File;
 
@@ -43,7 +43,7 @@ public class CameraPresenter implements ICameraPresenterContract.IPresenter {
                         .observeOn(AndroidSchedulers.mainThread())
                         .doFinally(() -> view.onAddingEnd())
                         .subscribe(bundle -> view.onAddSuccess(bundle), throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onAddError(throwable);
                         })
         );
@@ -59,7 +59,7 @@ public class CameraPresenter implements ICameraPresenterContract.IPresenter {
                         .observeOn(AndroidSchedulers.mainThread())
                         .doFinally(() -> view.onAddingEnd())
                         .subscribe(bundle -> view.onAddSuccess(bundle), throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onAddError(throwable);
                         })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CheckOdkServerPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CheckOdkServerPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
@@ -57,7 +57,7 @@ public class CheckOdkServerPresenter implements
                         view.onServerCheckSuccess(server);
                     }
                 }, throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onServerCheckError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CheckTUSServerPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CheckTUSServerPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
@@ -56,7 +56,7 @@ public class CheckTUSServerPresenter implements
                         view.onServerCheckFailure(uploadProgressInfo.status);
                     }
                 }, throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onServerCheckError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CollectBlankFormListPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CollectBlankFormListPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.javarosa.core.model.FormDef;
 
@@ -87,7 +87,7 @@ public class CollectBlankFormListPresenter implements
                 .subscribe(listFormResult -> {
                     // log errors if any in result..
                     for (IErrorBundle error : listFormResult.getErrors()) {
-                        Crashlytics.logException(error.getException());
+                        FirebaseCrashlytics.getInstance().recordException(error.getException());
                     }
 
                     view.onBlankFormsListResult(listFormResult);
@@ -95,7 +95,7 @@ public class CollectBlankFormListPresenter implements
                     if (throwable instanceof NoConnectivityException) {
                         view.onNoConnectionAvailable();
                     } else {
-                        Crashlytics.logException(throwable);
+                        FirebaseCrashlytics.getInstance().recordException(throwable);
                         view.onBlankFormsListError(throwable);
                     }
                 })
@@ -122,7 +122,7 @@ public class CollectBlankFormListPresenter implements
                 .flatMapCompletable(dataSource -> dataSource.removeBlankFormDef(form))
                 .subscribe(() -> view.onBlankFormDefRemoved(),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onBlankFormDefRemoveError(throwable);
                         })
         );
@@ -147,7 +147,7 @@ public class CollectBlankFormListPresenter implements
                 .subscribe(
                         formDef -> view.onDownloadBlankFormDefSuccess(form),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFormDefError(throwable);
                         }
                 )
@@ -173,7 +173,7 @@ public class CollectBlankFormListPresenter implements
                 .subscribe(
                         formDef -> view.onUpdateBlankFormDefSuccess(form, formDef),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFormDefError(throwable);
                         }
                 )

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CollectBlankFormListRefreshPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CollectBlankFormListRefreshPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -77,10 +77,10 @@ public class CollectBlankFormListRefreshPresenter implements
                 .subscribe(listFormResult -> {
                     // log errors if any in result..
                     for (IErrorBundle error : listFormResult.getErrors()) {
-                        Crashlytics.logException(error.getException());
+                        FirebaseCrashlytics.getInstance().recordException(error.getException());
                     }
                 }, throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onRefreshBlankFormsError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CollectMainPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CollectMainPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.javarosa.core.model.FormDef;
 
@@ -44,7 +44,7 @@ public class CollectMainPresenter implements ICollectMainPresenterContract.IPres
                 .subscribe(
                         formDef -> view.onGetBlankFormDefSuccess(form, formDef),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFormDefError(throwable);
                         }
                 )
@@ -61,7 +61,7 @@ public class CollectMainPresenter implements ICollectMainPresenterContract.IPres
                 ).subscribe(
                         instance -> view.onInstanceFormDefSuccess(maybeCloneInstance(instance)),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFormDefError(throwable);
                         }
                 )
@@ -78,7 +78,7 @@ public class CollectMainPresenter implements ICollectMainPresenterContract.IPres
                 .subscribe(
                         form -> view.onToggleFavoriteSuccess(form),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onToggleFavoriteError(throwable);
                         }
                 )
@@ -94,7 +94,7 @@ public class CollectMainPresenter implements ICollectMainPresenterContract.IPres
                 .subscribe(
                         () -> view.onFormInstanceDeleteSuccess(),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFormInstanceDeleteError(throwable);
                         }
                 )
@@ -110,7 +110,7 @@ public class CollectMainPresenter implements ICollectMainPresenterContract.IPres
                 .subscribe(
                         num -> view.onCountCollectServersEnded(num),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onCountCollectServersFailed(throwable);
                         }
                 )

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CollectServersPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/CollectServersPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ public class CollectServersPresenter implements ICollectServersPresenterContract
                 .doFinally(() -> view.hideLoading())
                 .subscribe(list -> view.onServersLoaded(list),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onLoadServersError(throwable);
                         })
         );
@@ -54,7 +54,7 @@ public class CollectServersPresenter implements ICollectServersPresenterContract
                 .doFinally(() -> view.hideLoading())
                 .subscribe(server1 -> view.onCreatedServer(server1),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onCreateCollectServerError(throwable);
                         })
         );
@@ -73,7 +73,7 @@ public class CollectServersPresenter implements ICollectServersPresenterContract
                             view.onUpdatedServer(server1);
                         },
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onUpdateServerError(throwable);
                         })
         );
@@ -91,7 +91,7 @@ public class CollectServersPresenter implements ICollectServersPresenterContract
                             view.onRemovedServer(server);
                         },
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onRemoveServerError(throwable);
                         })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/FormSubmitPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/FormSubmitPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import io.reactivex.SingleSource;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -32,7 +32,7 @@ public class FormSubmitPresenter implements IFormSubmitPresenterContract.IPresen
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(instance -> view.onGetFormInstanceSuccess(instance), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onGetFormInstanceError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/GalleryPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/GalleryPresenter.java
@@ -3,7 +3,7 @@ package rs.readahead.washington.mobile.mvp.presenter;
 import android.content.Context;
 import android.net.Uri;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,14 +17,11 @@ import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import rs.readahead.washington.mobile.data.database.CacheWordDataSource;
 import rs.readahead.washington.mobile.data.database.DataSource;
-import rs.readahead.washington.mobile.data.upload.TUSClient;
 import rs.readahead.washington.mobile.domain.entity.MediaFile;
-import rs.readahead.washington.mobile.domain.entity.TellaUploadServer;
 import rs.readahead.washington.mobile.domain.repository.IMediaFileRecordRepository;
 import rs.readahead.washington.mobile.media.MediaFileHandler;
 import rs.readahead.washington.mobile.mvp.contract.IGalleryPresenterContract;
 import rs.readahead.washington.mobile.presentation.entity.MediaFileThumbnailData;
-import timber.log.Timber;
 
 
 public class GalleryPresenter implements IGalleryPresenterContract.IPresenter {
@@ -53,7 +50,7 @@ public class GalleryPresenter implements IGalleryPresenterContract.IPresenter {
                     //checkMediaFolder(view.getContext(), mediaFiles);
                     view.onGetFilesSuccess(mediaFiles);
                 }, throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onGetFilesError(throwable);
                 })
         );
@@ -77,7 +74,7 @@ public class GalleryPresenter implements IGalleryPresenterContract.IPresenter {
                 .subscribe(mediaHolder ->
                             view.onMediaImported(mediaHolder.getMediaFile(), mediaHolder.getMediaFileThumbnailData()),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onImportError(throwable);
                         })
         );
@@ -92,7 +89,7 @@ public class GalleryPresenter implements IGalleryPresenterContract.IPresenter {
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onImportEnded())
                 .subscribe(mediaHolder -> view.onMediaImported(mediaHolder.getMediaFile(), mediaHolder.getMediaFileThumbnailData()), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onImportError(throwable);
                 })
         );
@@ -104,7 +101,7 @@ public class GalleryPresenter implements IGalleryPresenterContract.IPresenter {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(mediaFile1 -> view.onMediaFilesAdded(mediaFile1), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onMediaFilesAddingError(throwable);
                 })
         );
@@ -125,7 +122,7 @@ public class GalleryPresenter implements IGalleryPresenterContract.IPresenter {
                 })
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(num -> view.onMediaFilesDeleted(num), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onMediaFilesDeletionError(throwable);
                 })
         );
@@ -148,7 +145,7 @@ public class GalleryPresenter implements IGalleryPresenterContract.IPresenter {
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onExportEnded())
                 .subscribe(num -> view.onMediaExported(num), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onExportError(throwable);
                 })
         );
@@ -163,7 +160,7 @@ public class GalleryPresenter implements IGalleryPresenterContract.IPresenter {
                 .subscribe(
                         num -> view.onCountTUServersEnded(num),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onCountTUServersFailed(throwable);
                         }
                 )

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/HomeScreenPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/HomeScreenPresenter.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import info.guardianproject.cacheword.CacheWordHandler;
 import io.reactivex.Completable;
@@ -83,7 +83,7 @@ public class HomeScreenPresenter implements IHomeScreenPresenterContract.IPresen
                 .subscribe(
                         num -> view.onCountTUServersEnded(num),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onCountTUServersFailed(throwable);
                         }
                 )
@@ -99,7 +99,7 @@ public class HomeScreenPresenter implements IHomeScreenPresenterContract.IPresen
                 .subscribe(
                         num -> view.onCountCollectServersEnded(num),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onCountCollectServersFailed(throwable);
                         }
                 )

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/MediaFileViewerPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/MediaFileViewerPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.concurrent.Callable;
 
@@ -36,7 +36,7 @@ public class MediaFileViewerPresenter implements IMediaFileViewerPresenterContra
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onExportEnded())
                 .subscribe(() -> view.onMediaExported(), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onExportError(throwable);
                 })
         );
@@ -51,7 +51,7 @@ public class MediaFileViewerPresenter implements IMediaFileViewerPresenterContra
                                 MediaFileHandler.deleteMediaFile(view.getContext(), mediaFile1)).toCompletable())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(() -> view.onMediaFileDeleted(), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onMediaFileDeletionError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/MetadataAttacher.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/MetadataAttacher.java
@@ -1,9 +1,8 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
 import androidx.annotation.Nullable;
-
-import com.crashlytics.android.Crashlytics;
-
 import io.reactivex.SingleSource;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
@@ -47,7 +46,7 @@ public class MetadataAttacher implements IMetadataAttachPresenterContract.IPrese
                 }, new Consumer<Throwable>() {
                     @Override
                     public void accept(Throwable throwable) throws Exception {
-                        Crashlytics.logException(throwable);
+                        FirebaseCrashlytics.getInstance().recordException(throwable);
                         view.onMetadataAttachError(throwable);
                     }
                 })

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/ProtectionSettingsPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/ProtectionSettingsPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import io.reactivex.SingleSource;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -30,7 +30,7 @@ public class ProtectionSettingsPresenter implements IProtectionSettingsPresenter
                 .subscribe(
                         num -> view.onCountCollectServersEnded(num),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onCountCollectServersFailed(throwable);
                         }
                 )

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/QuestionAttachmentPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/QuestionAttachmentPresenter.java
@@ -1,12 +1,12 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
 import android.net.Uri;
-import androidx.annotation.Nullable;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.List;
 
+import androidx.annotation.Nullable;
 import io.reactivex.Observable;
 import io.reactivex.SingleSource;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -89,7 +89,7 @@ public class QuestionAttachmentPresenter implements IQuestionAttachmentPresenter
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onImportEnded())
                 .subscribe(mediaHolder -> view.onMediaFileImported(mediaHolder), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onImportError(throwable);
                 })
         );
@@ -104,7 +104,7 @@ public class QuestionAttachmentPresenter implements IQuestionAttachmentPresenter
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onImportEnded())
                 .subscribe(mediaHolder -> view.onMediaFileImported(mediaHolder), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onImportError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/ServersPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/ServersPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
@@ -31,7 +31,7 @@ public class ServersPresenter implements IServersPresenterContract.IPresenter {
                 .subscribe(
                         () -> view.onServersDeleted(),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onServersDeletedError(throwable);
                         }
                 )

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/SignaturePresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/SignaturePresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import io.reactivex.Observable;
 import io.reactivex.ObservableSource;
@@ -39,7 +39,7 @@ public class SignaturePresenter implements ISignaturePresenterContract.IPresente
                 .observeOn(AndroidSchedulers.mainThread())
                 .doFinally(() -> view.onAddingEnd())
                 .subscribe(mediaFile -> view.onAddSuccess(mediaFile), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onAddError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/TellaFileUploadPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/TellaFileUploadPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.List;
 
@@ -40,7 +40,7 @@ public class TellaFileUploadPresenter implements ITellaFileUploadPresenterContra
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(filesUploadInstances -> view.onGetFileUploadInstancesSuccess(filesUploadInstances), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onGetFileUploadInstancesError(throwable);
                 })
         );
@@ -53,7 +53,7 @@ public class TellaFileUploadPresenter implements ITellaFileUploadPresenterContra
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(filesUploadInstances -> view.onGetFileUploadSetInstancesSuccess(filesUploadInstances), throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onGetFileUploadSetInstancesError(throwable);
                 })
         );
@@ -67,7 +67,7 @@ public class TellaFileUploadPresenter implements ITellaFileUploadPresenterContra
                 .flatMapCompletable(dataSource -> dataSource.deleteFileUploadInstanceById(id))
                 .subscribe(() -> view.onFileUploadInstancesDeleted(),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFileUploadInstancesDeletionError(throwable);
                         })
         );
@@ -81,7 +81,7 @@ public class TellaFileUploadPresenter implements ITellaFileUploadPresenterContra
                 .flatMapCompletable(dataSource -> dataSource.deleteFileUploadInstancesBySet(set))
                 .subscribe(() -> view.onFileUploadInstancesDeleted(),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFileUploadInstancesDeletionError(throwable);
                         })
         );
@@ -95,7 +95,7 @@ public class TellaFileUploadPresenter implements ITellaFileUploadPresenterContra
                 .flatMapCompletable(dataSource -> dataSource.deleteFileUploadInstancesInStatus(status))
                 .subscribe(() -> view.onFileUploadInstancesDeleted(),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFileUploadInstancesDeletionError(throwable);
                         })
         );
@@ -109,7 +109,7 @@ public class TellaFileUploadPresenter implements ITellaFileUploadPresenterContra
                 .flatMapCompletable(dataSource -> dataSource.deleteFileUploadInstancesNotInStatus(status))
                 .subscribe(() -> view.onFileUploadInstancesDeleted(),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onFileUploadInstancesDeletionError(throwable);
                         })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/TellaFileUploadSchedulePresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/TellaFileUploadSchedulePresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.List;
 
@@ -42,7 +42,7 @@ public class TellaFileUploadSchedulePresenter implements ITellaFileUploadSchedul
                     TellaUploadJob.scheduleJob();
                     view.onMediaFilesUploadScheduled();
                 }, throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onMediaFilesUploadScheduleError(throwable);
                 })
         );
@@ -60,7 +60,7 @@ public class TellaFileUploadSchedulePresenter implements ITellaFileUploadSchedul
                     TellaUploadJob.scheduleJob();
                     view.onMediaFilesUploadScheduled();
                 }, throwable -> {
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                     view.onMediaFilesUploadScheduleError(throwable);
                 })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/TellaUploadDialogPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/TellaUploadDialogPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.List;
 
@@ -34,7 +34,7 @@ public class TellaUploadDialogPresenter implements ITellaUploadDialogPresenterCo
                         DataSource::listTellaUploadServers)
                 .subscribe(list -> view.onServersLoaded(list),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onServersLoadError(throwable);
                         })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/TellaUploadServersPresenter.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/mvp/presenter/TellaUploadServersPresenter.java
@@ -1,6 +1,6 @@
 package rs.readahead.washington.mobile.mvp.presenter;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.List;
 
@@ -38,7 +38,7 @@ public class TellaUploadServersPresenter implements ITellaUploadServersPresenter
                 .doFinally(() -> view.hideLoading())
                 .subscribe(list -> view.onTUServersLoaded(list),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onLoadTUServersError(throwable);
                         })
         );
@@ -54,7 +54,7 @@ public class TellaUploadServersPresenter implements ITellaUploadServersPresenter
                 .doFinally(() -> view.hideLoading())
                 .subscribe(server1 -> view.onCreatedTUServer(server1),
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onCreateTUServerError(throwable);
                         })
         );
@@ -73,7 +73,7 @@ public class TellaUploadServersPresenter implements ITellaUploadServersPresenter
                             view.onUpdatedTUServer(server1);
                         },
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onUpdateTUServerError(throwable);
                         })
         );
@@ -91,7 +91,7 @@ public class TellaUploadServersPresenter implements ITellaUploadServersPresenter
                             view.onRemovedTUServer(server);
                         },
                         throwable -> {
-                            Crashlytics.logException(throwable);
+                            FirebaseCrashlytics.getInstance().recordException(throwable);
                             view.onRemoveTUServerError(throwable);
                         })
         );

--- a/mobile/src/main/java/rs/readahead/washington/mobile/util/TelephonyUtils.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/util/TelephonyUtils.java
@@ -12,7 +12,7 @@ import android.telephony.CellInfoWcdma;
 import android.telephony.NeighboringCellInfo;
 import android.telephony.TelephonyManager;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,7 +56,7 @@ public class TelephonyUtils {
                 }
             }
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
         }
 
         return list;

--- a/mobile/src/main/java/rs/readahead/washington/mobile/util/jobs/TellaUploadJob.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/util/jobs/TellaUploadJob.java
@@ -1,9 +1,9 @@
 package rs.readahead.washington.mobile.util.jobs;
 
-import com.crashlytics.android.Crashlytics;
 import com.evernote.android.job.Job;
 import com.evernote.android.job.JobManager;
 import com.evernote.android.job.JobRequest;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -109,7 +109,7 @@ public class TellaUploadJob extends Job {
                         return;
                     }
                     Timber.d(throwable);
-                    Crashlytics.logException(throwable);
+                    FirebaseCrashlytics.getInstance().recordException(throwable);
                 });
 
         if (exitResult != null) {

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/CacheWordSubscriberBaseActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/CacheWordSubscriberBaseActivity.java
@@ -2,7 +2,7 @@ package rs.readahead.washington.mobile.views.activity;
 
 import android.os.Bundle;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import info.guardianproject.cacheword.CacheWordHandler;
 import info.guardianproject.cacheword.ICacheWordSubscriber;
@@ -60,7 +60,7 @@ public abstract class CacheWordSubscriberBaseActivity extends BaseActivity imple
             MyApplication application = (MyApplication) getApplication();
             application.createCacheWordHandler();
         } catch (Throwable e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
         }
     }
 }

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/CameraActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/CameraActivity.java
@@ -5,11 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.hardware.SensorManager;
 import android.os.Bundle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
-
 import android.view.OrientationEventListener;
 import android.view.View;
 import android.widget.ImageView;
@@ -19,7 +14,7 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.otaliastudios.cameraview.CameraException;
 import com.otaliastudios.cameraview.CameraListener;
 import com.otaliastudios.cameraview.CameraOptions;
@@ -41,6 +36,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -512,7 +510,7 @@ public class CameraActivity extends MetadataActivity implements
 
             @Override
             public void onCameraError(@NonNull CameraException exception) {
-                Crashlytics.logException(exception);
+                FirebaseCrashlytics.getInstance().recordException(exception);
             }
 
             @Override

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/SignatureActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/SignatureActivity.java
@@ -6,16 +6,16 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 import com.simplify.ink.InkView;
 
 import java.io.ByteArrayOutputStream;
 
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.Toolbar;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import rs.readahead.washington.mobile.R;
@@ -106,7 +106,7 @@ public class SignatureActivity extends CacheWordSubscriberBaseActivity implement
                 presenter.addPngImage(stream.toByteArray());
             }
         } catch (Exception exception) {
-            Crashlytics.logException(exception);
+            FirebaseCrashlytics.getInstance().recordException(exception);
         }
     }
 

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/AudioWidget.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/AudioWidget.java
@@ -4,16 +4,16 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import androidx.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.javarosa.form.api.FormEntryPrompt;
 
+import androidx.annotation.NonNull;
 import rs.readahead.washington.mobile.R;
 import rs.readahead.washington.mobile.domain.entity.MediaFile;
 import rs.readahead.washington.mobile.domain.repository.IMediaFileRecordRepository;
@@ -117,7 +117,7 @@ public class AudioWidget extends MediaFileBinaryWidget {
                     C.MEDIA_FILE_ID
             );
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             FormController.getActive().setIndexWaitingForData(null);
         }
     }
@@ -132,7 +132,7 @@ public class AudioWidget extends MediaFileBinaryWidget {
                     C.MEDIA_FILE_ID
             );
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             FormController.getActive().setIndexWaitingForData(null);
         }
     }

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/GeoPointWidget.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/GeoPointWidget.java
@@ -5,8 +5,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -15,7 +13,7 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.javarosa.core.model.data.GeoPointData;
 import org.javarosa.core.model.data.IAnswerData;
@@ -23,6 +21,8 @@ import org.javarosa.form.api.FormEntryPrompt;
 
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import rs.readahead.washington.mobile.MyApplication;
 import rs.readahead.washington.mobile.R;
 import rs.readahead.washington.mobile.bus.event.GPSProviderRequiredEvent;
@@ -227,7 +227,7 @@ public class GeoPointWidget extends QuestionWidget implements ILocationGettingPr
                     C.SELECTED_LOCATION
             );
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             FormController.getActive().setIndexWaitingForData(null);
         }
     }

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/ImageWidget.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/ImageWidget.java
@@ -4,16 +4,16 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import androidx.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.javarosa.form.api.FormEntryPrompt;
 
+import androidx.annotation.NonNull;
 import rs.readahead.washington.mobile.R;
 import rs.readahead.washington.mobile.domain.entity.MediaFile;
 import rs.readahead.washington.mobile.domain.repository.IMediaFileRecordRepository;
@@ -126,7 +126,7 @@ public class ImageWidget extends MediaFileBinaryWidget {
                     C.MEDIA_FILE_ID
             );
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             FormController.getActive().setIndexWaitingForData(null);
         }
     }
@@ -142,7 +142,7 @@ public class ImageWidget extends MediaFileBinaryWidget {
                     C.MEDIA_FILE_ID
             );
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             FormController.getActive().setIndexWaitingForData(null);
         }
     }

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/SignatureWidget.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/SignatureWidget.java
@@ -4,7 +4,6 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import androidx.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
@@ -16,10 +15,11 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.javarosa.form.api.FormEntryPrompt;
 
+import androidx.annotation.NonNull;
 import rs.readahead.washington.mobile.R;
 import rs.readahead.washington.mobile.data.database.CacheWordDataSource;
 import rs.readahead.washington.mobile.domain.entity.MediaFile;
@@ -132,7 +132,7 @@ public class SignatureWidget extends MediaFileBinaryWidget implements ICollectAt
                     C.MEDIA_FILE_ID
             );
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             FormController.getActive().setIndexWaitingForData(null);
         }
     }
@@ -204,7 +204,7 @@ public class SignatureWidget extends MediaFileBinaryWidget implements ICollectAt
                     .putExtra(PhotoViewerActivity.VIEW_PHOTO, mediaFile)
                     .putExtra(PhotoViewerActivity.NO_ACTIONS, true));
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
         }
     }
 

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/VideoWidget.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/collect/widgets/VideoWidget.java
@@ -4,16 +4,16 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import androidx.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.javarosa.form.api.FormEntryPrompt;
 
+import androidx.annotation.NonNull;
 import rs.readahead.washington.mobile.R;
 import rs.readahead.washington.mobile.domain.entity.MediaFile;
 import rs.readahead.washington.mobile.domain.repository.IMediaFileRecordRepository;
@@ -124,7 +124,7 @@ public class VideoWidget extends MediaFileBinaryWidget {
                             .putExtra(QuestionAttachmentActivity.MEDIA_FILES_FILTER, IMediaFileRecordRepository.Filter.VIDEO),
                     C.MEDIA_FILE_ID);
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             FormController.getActive().setIndexWaitingForData(null);
         }
     }
@@ -140,7 +140,7 @@ public class VideoWidget extends MediaFileBinaryWidget {
                     C.MEDIA_FILE_ID
             );
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
             FormController.getActive().setIndexWaitingForData(null);
         }
     }

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/custom/CollectAttachmentPreviewView.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/custom/CollectAttachmentPreviewView.java
@@ -15,7 +15,7 @@ import android.widget.Toast;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -176,7 +176,7 @@ public class CollectAttachmentPreviewView extends LinearLayout implements IColle
                     .putExtra(VideoViewerActivity.VIEW_VIDEO, mediaFile)
                     .putExtra(VideoViewerActivity.NO_ACTIONS, true));
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
         }
     }
 
@@ -191,7 +191,7 @@ public class CollectAttachmentPreviewView extends LinearLayout implements IColle
                     .putExtra(PhotoViewerActivity.VIEW_PHOTO, mediaFile)
                     .putExtra(PhotoViewerActivity.NO_ACTIONS, true));
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
         }
     }
 
@@ -206,7 +206,7 @@ public class CollectAttachmentPreviewView extends LinearLayout implements IColle
                     .putExtra(AudioPlayActivity.PLAY_MEDIA_FILE, mediaFile)
                     .putExtra(AudioPlayActivity.NO_ACTIONS, true));
         } catch (Exception e) {
-            Crashlytics.logException(e);
+            FirebaseCrashlytics.getInstance().recordException(e);
         }
     }
 }


### PR DESCRIPTION
Pull requests should be opened against the `develop` branch. For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change

**Description:**
PR implements replacement of Fabric.io deprecated crashalytics support with Firebase Crashalytics lib.

**Select the type of change(s) made in this pull request:**
- [ ] Bug fix *(Fixes an issue)*
- [x] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------

## Proposed changes 
PR implements replacement of Fabric.io deprecated crashalytics support with Firebase Crashalytics lib.