### PR TITLE
Update upload job starting conditions

### DIFF
--- a/mobile/src/main/java/rs/readahead/washington/mobile/util/jobs/TellaUploadJob.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/util/jobs/TellaUploadJob.java
@@ -42,8 +42,12 @@ public class TellaUploadJob extends Job {
     @NonNull
     @Override
     protected Result onRunJob(@NotNull Job.Params params) {
-        if (!enter() || Preferences.isAutoUploadPaused()) {
+        if (!enter()) {
             return Result.SUCCESS;
+        }
+
+        if (Preferences.isAutoUploadPaused() || Preferences.isOfflineMode()) {
+            return exit(Result.RESCHEDULE);
         }
 
         KeyBundle keyBundle = MyApplication.getKeyBundle();
@@ -113,7 +117,7 @@ public class TellaUploadJob extends Job {
                 });
 
         if (exitResult != null) {
-            exit(exitResult);
+            return exit(exitResult);
         }
 
         return exit(Result.SUCCESS);


### PR DESCRIPTION
## Type of change

**Description:**
If offline mode is on, upload should not start. Fix checking conditions to start the upload job.

**Select the type of change(s) made in this pull request:**
Bugfix (Fixes an issue)

----------------------------------------------------------------------------------------

## Proposed changes 
UploadJob checks the state of "offline mode" and if it is on, upload does not start. Checking whether the job is started is done separately from checking other conditions for starting the upload.