### PR TITLE
Remove CacheWordHandler from pattern upgrade activity.

### DIFF
--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/BaseLockActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/BaseLockActivity.java
@@ -9,7 +9,6 @@ import info.guardianproject.cacheword.SecretsManager;
 import rs.readahead.washington.mobile.MyApplication;
 
 public abstract class BaseLockActivity extends BaseActivity {
-
     private boolean locked;
 
     private void restrictActivity() {
@@ -29,18 +28,16 @@ public abstract class BaseLockActivity extends BaseActivity {
     }
 
     protected void startKeySetup() {
-        Intent intent = new Intent(this, SecretsManager.isInitialized(this)  ? PatternUpgradeActivity.class : PatternSetActivity.class);
+        Intent intent = new Intent(this, SecretsManager.isInitialized(this) ? PatternUpgradeActivity.class : PatternSetActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         this.startActivity(intent);
     }
-
 
     protected void startUnlockingMainKey() {
         Intent intent = new Intent(this, PatternUnlockActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
         this.startActivity(intent);
     }
-
 
     @Override
     protected void onResume() {

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/PatternUpgradeActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/PatternUpgradeActivity.java
@@ -49,15 +49,14 @@ public class PatternUpgradeActivity extends ConfirmPatternActivity {
         dialog = DialogsUtil.showProgressDialog(this, getString(R.string.lock_dialog_expl_unlock_app));
 
         try {
-            char[] passphrase = PatternUtils.patternToSha1String(pattern).toCharArray();
-
-            PassphraseSecrets secrets = PassphraseSecrets.fetchSecrets(this, passphrase);
+            PassphraseSecrets secrets = PassphraseSecrets.fetchSecrets(this, PatternUtils.patternToSha1String(pattern).toCharArray());
             MainKey mainKey = new MainKey(new SecretKeySpec(secrets.getSecretKey().getEncoded(), "AES"));
+            PBEKeySpec keySpec = new PBEKeySpec(PatternUtils.patternToSha1String(pattern).toCharArray());
 
             IUnlockRegistryHolder holder = (IUnlockRegistryHolder) getApplicationContext();
             UnlockConfig config = holder.getUnlockRegistry().getActiveConfig(this);
 
-            TellaKeysUI.getMainKeyStore().store(mainKey, config.wrapper, new PBEKeySpec(passphrase), new MainKeyStore.IMainKeyStoreCallback() {
+            TellaKeysUI.getMainKeyStore().store(mainKey, config.wrapper, keySpec, new MainKeyStore.IMainKeyStoreCallback() {
                 @Override
                 public void onSuccess(MainKey mainKey) {
                     Timber.d("** MainKey stored: %s **", mainKey);

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/PatternUpgradeActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/PatternUpgradeActivity.java
@@ -14,6 +14,7 @@ import com.hzontal.tella_locking_ui.patternlock.PatternView;
 import org.hzontal.tella.keys.MainKeyStore;
 import org.hzontal.tella.keys.config.IUnlockRegistryHolder;
 import org.hzontal.tella.keys.config.UnlockConfig;
+import org.hzontal.tella.keys.config.UnlockRegistry;
 import org.hzontal.tella.keys.key.MainKey;
 
 import java.security.GeneralSecurityException;
@@ -54,6 +55,7 @@ public class PatternUpgradeActivity extends ConfirmPatternActivity {
             PBEKeySpec keySpec = new PBEKeySpec(PatternUtils.patternToSha1String(pattern).toCharArray());
 
             IUnlockRegistryHolder holder = (IUnlockRegistryHolder) getApplicationContext();
+            holder.getUnlockRegistry().setActiveMethod(PatternUpgradeActivity.this, UnlockRegistry.Method.TELLA_PATTERN);
             UnlockConfig config = holder.getUnlockRegistry().getActiveConfig(this);
 
             TellaKeysUI.getMainKeyStore().store(mainKey, config.wrapper, keySpec, new MainKeyStore.IMainKeyStoreCallback() {

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/PatternUpgradeActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/PatternUpgradeActivity.java
@@ -2,7 +2,6 @@ package rs.readahead.washington.mobile.views.activity;
 
 import android.app.ProgressDialog;
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -15,7 +14,6 @@ import com.hzontal.tella_locking_ui.patternlock.PatternView;
 import org.hzontal.tella.keys.MainKeyStore;
 import org.hzontal.tella.keys.config.IUnlockRegistryHolder;
 import org.hzontal.tella.keys.config.UnlockConfig;
-import org.hzontal.tella.keys.config.UnlockRegistry;
 import org.hzontal.tella.keys.key.MainKey;
 
 import java.security.GeneralSecurityException;
@@ -24,18 +22,13 @@ import java.util.List;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import info.guardianproject.cacheword.CacheWordHandler;
-import info.guardianproject.cacheword.ICacheWordSubscriber;
 import info.guardianproject.cacheword.PassphraseSecrets;
 import rs.readahead.washington.mobile.R;
 import rs.readahead.washington.mobile.util.DialogsUtil;
 import rs.readahead.washington.mobile.util.LocaleManager;
 import timber.log.Timber;
 
-
-
-public class PatternUpgradeActivity extends ConfirmPatternActivity implements ICacheWordSubscriber {
-    private CacheWordHandler mCacheWord;
+public class PatternUpgradeActivity extends ConfirmPatternActivity {
     private ProgressDialog dialog;
 
     @Override
@@ -47,8 +40,6 @@ public class PatternUpgradeActivity extends ConfirmPatternActivity implements IC
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mCacheWord = new CacheWordHandler(this);
-
         Button button = findViewById(R.id.pl_right_button);
         button.setVisibility(View.INVISIBLE);
     }
@@ -56,14 +47,17 @@ public class PatternUpgradeActivity extends ConfirmPatternActivity implements IC
     @Override
     protected boolean isPatternCorrect(List<PatternView.Cell> pattern) {
         dialog = DialogsUtil.showProgressDialog(this, getString(R.string.lock_dialog_expl_unlock_app));
+
         try {
-            PassphraseSecrets secrets = PassphraseSecrets.fetchSecrets(
-                    this, PatternUtils.patternToSha1String(pattern).toCharArray());
-            mCacheWord.setCachedSecrets(secrets);
+            char[] passphrase = PatternUtils.patternToSha1String(pattern).toCharArray();
+
+            PassphraseSecrets secrets = PassphraseSecrets.fetchSecrets(this, passphrase);
+            MainKey mainKey = new MainKey(new SecretKeySpec(secrets.getSecretKey().getEncoded(), "AES"));
+
             IUnlockRegistryHolder holder = (IUnlockRegistryHolder) getApplicationContext();
-            holder.getUnlockRegistry().setActiveMethod(PatternUpgradeActivity.this, UnlockRegistry.Method.TELLA_PATTERN);
             UnlockConfig config = holder.getUnlockRegistry().getActiveConfig(this);
-            TellaKeysUI.getMainKeyStore().store(new MainKey(new SecretKeySpec(secrets.getSecretKey().getEncoded(), "AES")), config.wrapper, new PBEKeySpec(PatternUtils.patternToSha1String(pattern).toCharArray()), new MainKeyStore.IMainKeyStoreCallback() {
+
+            TellaKeysUI.getMainKeyStore().store(mainKey, config.wrapper, new PBEKeySpec(passphrase), new MainKeyStore.IMainKeyStoreCallback() {
                 @Override
                 public void onSuccess(MainKey mainKey) {
                     Timber.d("** MainKey stored: %s **", mainKey);
@@ -76,28 +70,13 @@ public class PatternUpgradeActivity extends ConfirmPatternActivity implements IC
                     Timber.e(throwable, "** MainKey store error **");
                 }
             });
+
             return true;
         } catch (final GeneralSecurityException e) {
             Timber.d(e, getClass().getName());
             dismissDialog();
             return false;
         }
-    }
-
-    @Override
-    public void onCacheWordUninitialized() {
-    }
-
-    @Override
-    public void onCacheWordLocked() {
-    }
-
-    @Override
-    public void onCacheWordOpened() {
-        dismissDialog();
-        startActivity(new Intent(this, MainActivity.class));
-        finish();
-        overridePendingTransition(0, 0);
     }
 
     @Override

--- a/tella-keys/src/main/java/org/hzontal/tella/keys/config/UnlockRegistry.java
+++ b/tella-keys/src/main/java/org/hzontal/tella/keys/config/UnlockRegistry.java
@@ -16,8 +16,8 @@ import androidx.annotation.NonNull;
 import androidx.biometric.BiometricManager;
 
 public class UnlockRegistry {
-    private Map<Method, UnlockConfig> configs = new HashMap<>();
-    private Map<String, UnlockResult> results = new HashMap<>();
+    private final Map<Method, UnlockConfig> configs = new HashMap<>();
+    private final Map<String, UnlockResult> results = new HashMap<>();
 
     public void putResult(String name, UnlockResult result) {
         results.put(name, result);
@@ -45,6 +45,7 @@ public class UnlockRegistry {
     }
 
     // capabilities
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean isDeviceCredentialsAvailable() {
         // todo: check why exactly we do not go for 21 (something about changing the pass removes the keys)
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;

--- a/tella-keys/src/main/java/org/hzontal/tella/keys/wrapper/AndroidKeyStoreHelper.java
+++ b/tella-keys/src/main/java/org/hzontal/tella/keys/wrapper/AndroidKeyStoreHelper.java
@@ -33,8 +33,7 @@ public class AndroidKeyStoreHelper {
 
     @RequiresApi(Build.VERSION_CODES.M)
     public static WrappedMainKey wrap(@NonNull byte[] input, IMainKeyWrapper wrapper) {
-        // SecretKey secretKey = hasKey() ? getKey() : createKey();
-        SecretKey secretKey = createKey();
+        SecretKey secretKey = hasKey() ? getKey() : createKey();
 
         try {
             Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
@@ -78,7 +77,7 @@ public class AndroidKeyStoreHelper {
                     .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                     .setUserAuthenticationRequired(true)
-                    .setUserAuthenticationValidityDurationSeconds(10) // todo: can this be avoided and still require auth in "real world"
+                    .setUserAuthenticationValidityDurationSeconds(10)
                     .build();
 
             keyGenerator.init(keyGenParameterSpec);

--- a/tella-keys/src/main/java/org/hzontal/tella/keys/wrapper/IMainKeyWrapper.java
+++ b/tella-keys/src/main/java/org/hzontal/tella/keys/wrapper/IMainKeyWrapper.java
@@ -5,12 +5,10 @@ import org.hzontal.tella.keys.key.WrappedMainKey;
 
 import java.security.spec.KeySpec;
 
-import javax.crypto.SecretKey;
-
 public interface IMainKeyWrapper {
     String getName();
 
-    void wrap(MainKey mainKey, KeySpec keySpec, IWrapCallback callback); // todo: KeySpec not Key
+    void wrap(MainKey mainKey, KeySpec keySpec, IWrapCallback callback);
     void unwrap(WrappedMainKey mainKey, KeySpec keySpec, IUnwrapCallback callback);
 
     interface IWrapCallback {

--- a/tella-keys/src/main/java/org/hzontal/tella/keys/wrapper/PBEKeyWrapper.java
+++ b/tella-keys/src/main/java/org/hzontal/tella/keys/wrapper/PBEKeyWrapper.java
@@ -1,7 +1,5 @@
 package org.hzontal.tella.keys.wrapper;
 
-import android.os.Build;
-
 import org.hzontal.tella.keys.key.MainKey;
 import org.hzontal.tella.keys.key.WrappedMainKey;
 
@@ -13,11 +11,9 @@ import java.security.spec.KeySpec;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
-
-import androidx.annotation.RequiresApi;
 
 public class PBEKeyWrapper implements IMainKeyWrapper {
     @Override
@@ -32,7 +28,7 @@ public class PBEKeyWrapper implements IMainKeyWrapper {
 
             byte[] salt = generateSalt();
             int iterationCount = calculateIterationCount();
-            SecretKeySpec secretKeySpec = createAESKey(pbeKeySpec.getPassword(), salt, iterationCount); // todo: just receive password here..
+            SecretKeySpec secretKeySpec = createAESKey(pbeKeySpec.getPassword(), salt, iterationCount);
 
             Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
             cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
@@ -53,17 +49,16 @@ public class PBEKeyWrapper implements IMainKeyWrapper {
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.KITKAT) // todo: handle this
     @Override
     public void unwrap(WrappedMainKey wrapped, KeySpec keySpec, IUnwrapCallback callback) {
         try {
             PBEKeySpec pbeKeySpec = (PBEKeySpec) keySpec;
 
             SecretKeySpec secretKeySpec = createAESKey(pbeKeySpec.getPassword(),
-                    wrapped.salt, wrapped.iterationCount); // todo: just receive password here..
+                    wrapped.salt, wrapped.iterationCount);
 
             Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
-            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, new GCMParameterSpec(128, wrapped.iv));
+            cipher.init(Cipher.DECRYPT_MODE, secretKeySpec, new IvParameterSpec(wrapped.iv));
             byte[] key = cipher.doFinal(wrapped.data);
 
             MainKey mainKey = new MainKey(new SecretKeySpec(key, "AES"));
@@ -77,7 +72,7 @@ public class PBEKeyWrapper implements IMainKeyWrapper {
      SecretKeySpec createAESKey(char[] password, byte[] salt, int iterationCount)
             throws NoSuchAlgorithmException, InvalidKeySpecException {
         KeySpec keySpec = new PBEKeySpec(password, salt, iterationCount, 128);
-        SecretKeyFactory factory = SecretKeyFactory.getInstance(getAlgorithm()); // todo: check this
+        SecretKeyFactory factory = SecretKeyFactory.getInstance(getAlgorithm());
         SecretKey sk = factory.generateSecret(keySpec);
 
         return new SecretKeySpec(sk.getEncoded(), "AES");
@@ -97,8 +92,7 @@ public class PBEKeyWrapper implements IMainKeyWrapper {
     }
 
     private int calculateIterationCount() {
-
-
+        // todo: implement this
         return getIterationCount();
     }
 

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/pattern/PatternUnlockActivity.kt
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/pattern/PatternUnlockActivity.kt
@@ -8,15 +8,11 @@ import com.hzontal.tella_locking_ui.patternlock.ConfirmPatternActivity
 import com.hzontal.tella_locking_ui.patternlock.PatternUtils
 import com.hzontal.tella_locking_ui.patternlock.PatternView
 import org.hzontal.tella.keys.MainKeyStore.IMainKeyLoadCallback
-import org.hzontal.tella.keys.TellaKeys
 import org.hzontal.tella.keys.key.MainKey
 import timber.log.Timber
 import javax.crypto.spec.PBEKeySpec
 
-
 class PatternUnlockActivity : ConfirmPatternActivity() {
-
-    private lateinit var mNewPassphrase: String
     private var isPatternCorrect = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,12 +22,12 @@ class PatternUnlockActivity : ConfirmPatternActivity() {
     }
 
     override fun isPatternCorrect(pattern: MutableList<PatternView.Cell>?): Boolean {
-        mNewPassphrase = PatternUtils.patternToSha1String(pattern)
+        val passphrase = PatternUtils.patternToSha1String(pattern).toCharArray()
 
-        TellaKeysUI.getMainKeyStore().load(config.wrapper, PBEKeySpec(mNewPassphrase.toCharArray()), object : IMainKeyLoadCallback {
+        TellaKeysUI.getMainKeyStore().load(config.wrapper, PBEKeySpec(passphrase), object : IMainKeyLoadCallback {
             override fun onReady(mainKey: MainKey) {
                 Timber.d("*** MainKeyStore.IMainKeyLoadCallback.onReady")
-                getMainKeyHolder().set(mainKey);
+                getMainKeyHolder().set(mainKey)
                 TellaKeysUI.getCredentialsCallback().onSuccessfulUnlock(this@PatternUnlockActivity)
                 isPatternCorrect = true
             }
@@ -50,5 +46,4 @@ class PatternUnlockActivity : ConfirmPatternActivity() {
         super.onConfirmed()
         finish()
     }
-
 }


### PR DESCRIPTION
## Type of change

Removal of `CacheWordSubscriber` from `PatternUpgradeActivity` making use of CW passive. Apart from that, added small changes to make `PBEKeyWrapper` work bellow KitKat.


**Select the type of change(s) made in this pull request:**
- [ ] Bug fix *(Fixes an issue)*
- [x] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------

