### PR TITLE
Create generic bottom sheet 

### DIFF
--- a/shared-ui/src/main/AndroidManifest.xml
+++ b/shared-ui/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.hzontal.shared_ui">
+    package="org.hzontal.shared_ui">
 
 </manifest>

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/BottomSheetUtils.kt
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/BottomSheetUtils.kt
@@ -3,7 +3,7 @@ package org.hzontal.shared_ui.bottomsheet
 import android.view.View
 import android.widget.TextView
 import androidx.fragment.app.FragmentManager
-import com.hzontal.shared_ui.R
+import org.hzontal.shared_ui.R
 
 object BottomSheetUtils {
 

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/BottomSheetUtils.kt
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/BottomSheetUtils.kt
@@ -1,0 +1,72 @@
+package org.hzontal.shared_ui.bottomsheet
+
+import android.view.View
+import android.widget.TextView
+import androidx.fragment.app.FragmentManager
+import com.hzontal.shared_ui.R
+
+object BottomSheetUtils {
+
+    fun showStandardSheet(
+            fragmentManager: FragmentManager,
+            titleText: String?,
+            descriptionText: String?,
+            actionButtonLabel: String? = null,
+            cancelButtonLabel: String? = null,
+            onConfirmClick: (() -> Unit)? = null,
+            onCancelClick: (() -> Unit)? = null
+    ) {
+
+        val customSheetFragment = CustomBottomSheetFragment.with(fragmentManager)
+                .page(R.layout.standar_sheet_layout)
+                .cancellable(true)
+        customSheetFragment.holder(GenericSheetHolder(), object :
+                CustomBottomSheetFragment.Binder<GenericSheetHolder> {
+            override fun onBind(holder: GenericSheetHolder) {
+                with(holder) {
+                    title.text = titleText
+                    description.text = descriptionText
+                    actionButtonLabel?.let {
+                        actionButton.text = it
+                    }
+                    cancelButtonLabel?.let {
+                        cancelButton.text = it
+                    }
+
+                    actionButton.setOnClickListener {
+                        onConfirmClick?.invoke()
+                        customSheetFragment.dismiss()
+                    }
+
+                    cancelButton.setOnClickListener {
+                        onCancelClick?.invoke()
+                        customSheetFragment.dismiss()
+                    }
+
+                    actionButton.visibility =
+                            if (actionButtonLabel.isNullOrEmpty()) View.GONE else View.VISIBLE
+
+                }
+            }
+        })
+
+        customSheetFragment.transparentBackground()
+        customSheetFragment.launch()
+    }
+
+    class GenericSheetHolder : CustomBottomSheetFragment.PageHolder() {
+        lateinit var actionButton: TextView
+        lateinit var cancelButton: TextView
+        lateinit var title: TextView
+        lateinit var description: TextView
+
+        override fun bindView(view: View) {
+            actionButton = view.findViewById(R.id.standard_sheet_confirm_btn)
+            cancelButton = view.findViewById(R.id.standard_sheet_cancel_btn)
+            title = view.findViewById(R.id.standard_sheet_title)
+            description = view.findViewById(R.id.standard_sheet_content)
+        }
+    }
+
+
+}

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/CustomBottomSheetFragment.kt
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/CustomBottomSheetFragment.kt
@@ -1,0 +1,256 @@
+package org.hzontal.shared_ui.bottomsheet
+
+import android.content.DialogInterface
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import android.os.Bundle
+import android.util.Pair
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import androidx.annotation.ColorRes
+import androidx.annotation.IdRes
+import androidx.annotation.LayoutRes
+import androidx.annotation.StyleRes
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.hzontal.shared_ui.R
+import java.util.*
+
+class CustomBottomSheetFragment : BottomSheetDialogFragment() {
+
+    @LayoutRes
+    private var layoutRes: Int = 0
+
+    private lateinit var manager: FragmentManager
+    private val clickers = ArrayList<Pair<Int, () -> Unit>>()
+    private var backClickListener: (() -> Unit)? = null
+
+    private var screenTag: String? = null
+
+    @ColorRes
+    private var statusBarColor: Int? = null
+
+    @StyleRes
+    private var animationStyle: Int? = null
+
+    private var binder: Binder<PageHolder>? = null
+    private var pageHolder: PageHolder? = null
+    private var isCancellable = false
+    private var isTransparent: Boolean = false
+
+    /**
+     * Called to init LayoutRes with ID layout.
+     * Mandatory
+     *
+     * @param layoutRes ID layout to setContentView on CustomBottomSheetFragment Activity
+     * @return Instantiated CustomBottomSheetFragment object
+     */
+    fun page(@LayoutRes layoutRes: Int): CustomBottomSheetFragment {
+        this.layoutRes = layoutRes
+        return this
+    }
+
+    /**
+     * Called to init setStatusBarColor with color Res Id.
+     * Mandatory
+     *
+     * @param statusBarColor ColorRes
+     * @return Instantiated CustomBottomSheetFragment object
+     */
+    fun statusBarColor(@ColorRes statusBarColor: Int): CustomBottomSheetFragment {
+        this.statusBarColor = statusBarColor
+        return this
+    }
+
+    fun animate(@StyleRes animationStyle: Int): CustomBottomSheetFragment {
+        this.animationStyle = animationStyle
+        return this
+    }
+
+    /**
+     * Called to init HashSet<Pair></Pair><Integer></Integer>, Clicker>> clickers with IDView and Clicker
+     *
+     * @param idRes ID View to findViewById on Activity
+     * @param clicker OnClickListener
+     * @return Instantiated CustomBottomSheetFragment object
+     */
+    fun click(@IdRes idRes: Int, clicker: () -> Unit): CustomBottomSheetFragment {
+        this.clickers.add(Pair(idRes, clicker))
+        return this
+    }
+
+    /**
+     * Called to init PageHolder with a View extends PageHolder Object
+     *
+     * @param pageHolder CustomView for ButterKnife.bind on Message Activity
+     * @param binder Interface for bind CustomView extends PageHolder
+     * @param <T> CustomView Object
+     * @return Instantiated CustomView
+    </T> */
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : PageHolder> holder(pageHolder: T, binder: Binder<T>): CustomBottomSheetFragment {
+        this.pageHolder = pageHolder
+        this.binder = binder as Binder<PageHolder>
+        return this
+    }
+
+    /**
+     * Called to init an action for @Override BackPressed method
+     *
+     * @param listener OnClickListener
+     * @return Instantiated CustomBottomSheetFragment object
+     */
+    fun back(listener: () -> Unit): CustomBottomSheetFragment {
+        this.backClickListener = listener
+        return this
+    }
+
+    /**
+     * Called to init screenTag for tracking
+     *
+     * @return Instantiated CustomBottomSheetFragment object
+     */
+    fun screenTag(screenTag: String): CustomBottomSheetFragment {
+        this.screenTag = screenTag
+        return this
+    }
+
+    /**
+     * Called to set Dialog fragment to full screen
+     *
+     * @return Instantiated CustomBottomSheetFragment object
+     */
+    fun fullScreen(): CustomBottomSheetFragment {
+        setStyle(DialogFragment.STYLE_NO_TITLE, R.style.AppBottomSheetDialogTheme)
+        return this
+    }
+
+    /**
+     * Called to set Dialog fragment background transparent
+     *
+     * @return Instantiated CustomBottomSheetFragment object
+     */
+    fun transparentBackground(): CustomBottomSheetFragment {
+        isTransparent = true
+        return this
+    }
+
+    /**
+     * Called to set Dialog fragment cancellable
+     *
+     * @return Instantiated CustomBottomSheetFragment object
+     */
+    fun cancellable(isCancellable: Boolean): CustomBottomSheetFragment {
+        this.isCancellable = isCancellable
+        return this
+    }
+
+    fun launch() {
+        val tag = screenTag ?: "MESSAGE"
+        showOnce(manager, tag)
+    }
+
+    override fun onStart() {
+        if (dialog != null && dialog!!.window != null) {
+            dialog?.let {
+                it.window?.let { window ->
+                    if (animationStyle != null) window.attributes.windowAnimations =
+                        animationStyle!!
+                    if (isTransparent) window.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+                }
+            }
+
+        }
+        super.onStart()
+    }
+
+    override fun getTheme(): Int {
+        return R.style.AppBottomSheetDialogTheme
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NORMAL, R.style.AppBottomSheetDialogTheme)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        super.onCreateView(inflater, container, savedInstanceState)
+        return inflater.inflate(layoutRes, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        for (i in clickers.indices) {
+            val viewClick = clickers[i]
+            view.findViewById<View>(viewClick.first).setOnClickListener { viewClick.second() }
+        }
+
+        pageHolder?.let {
+            it.bindView(view)
+            binder?.onBind(it)
+        }
+
+        isCancelable = isCancellable
+        configBackPressCallback()
+        if (statusBarColor != null) applyStatusBarColor(statusBarColor!!)
+    }
+
+    private fun configBackPressCallback() {
+        dialog!!.setOnKeyListener(DialogInterface.OnKeyListener { _, keyCode, _ ->
+            if (keyCode == android.view.KeyEvent.KEYCODE_BACK) {
+                backClickListener?.invoke()
+                return@OnKeyListener true
+            }
+            false
+        })
+    }
+
+    private fun applyStatusBarColor(@ColorRes colorInt: Int) {
+        val window = dialog!!.window
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            if (window != null) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
+                window.statusBarColor = ContextCompat.getColor(requireContext(), colorInt)
+            }
+        }
+    }
+
+    interface Binder<T : PageHolder> {
+        fun onBind(holder: T)
+    }
+
+    abstract class PageHolder {
+        abstract fun bindView(view: View)
+    }
+
+    companion object {
+        /**
+         * Called to init CustomBottomSheetFragment object with fragmentManager.
+         * Mandatory
+         *
+         * @param fragmentManager Object used to launch CustomBottomSheetFragment
+         * @return Instantiated CustomBottomSheetFragment object
+         */
+        fun with(fragmentManager: FragmentManager): CustomBottomSheetFragment {
+            val process = CustomBottomSheetFragment()
+            process.manager = fragmentManager
+            return process
+        }
+    }
+}
+
+fun DialogFragment.showOnce(manager: FragmentManager, tag: String) {
+    if (manager.findFragmentByTag(tag) == null) {
+        show(manager, tag)
+    }
+}

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/CustomBottomSheetFragment.kt
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/CustomBottomSheetFragment.kt
@@ -18,7 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.hzontal.shared_ui.R
+import org.hzontal.shared_ui.R
 import java.util.*
 
 class CustomBottomSheetFragment : BottomSheetDialogFragment() {

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/buttons/InformationButton.kt
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/buttons/InformationButton.kt
@@ -11,7 +11,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
-import com.hzontal.shared_ui.R
+import org.hzontal.shared_ui.R
 
 
 class InformationButton @JvmOverloads constructor(

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/utils/DialogUtils.java
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/utils/DialogUtils.java
@@ -9,7 +9,7 @@ import android.widget.TextView;
 
 import androidx.annotation.ColorRes;
 
-import com.hzontal.shared_ui.R;
+import org.hzontal.shared_ui.R;
 
 
 public class DialogUtils {

--- a/shared-ui/src/main/res/drawable/drag_anchor_drawable.xml
+++ b/shared-ui/src/main/res/drawable/drag_anchor_drawable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/wa_purple" />
+    <corners
+        android:topLeftRadius="20dp"
+        android:topRightRadius="20dp" />
+</shape>

--- a/shared-ui/src/main/res/layout/standar_sheet_layout.xml
+++ b/shared-ui/src/main/res/layout/standar_sheet_layout.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@drawable/drag_anchor_drawable"
+    app:behavior_hideable="true"
+    android:padding="21dp">
+
+    <TextView
+        android:id="@+id/standard_sheet_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Test "
+        android:textFontWeight="700"
+        android:textColor="@color/wa_white"
+        android:fontFamily="@font/open_sans"
+        android:textSize="21sp"
+        />
+
+    <TextView
+        android:id="@+id/standard_sheet_content"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/standard_sheet_title"
+        tools:text="TestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTestTest "
+        android:layout_marginTop="10dp"
+        android:textFontWeight="400"
+        android:lineHeight="21dp"
+        android:textColor="@color/wa_white"
+        android:fontFamily="@font/open_sans"
+        android:textSize="14sp"
+        />
+
+
+    <TextView
+        android:id="@+id/standard_sheet_cancel_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toStartOf="@id/standard_sheet_confirm_btn"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/standard_sheet_content"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        tools:text="Cancel"
+        android:layout_marginTop="40dp"
+        android:textFontWeight="600"
+        android:textColor="@color/wa_white"
+        android:fontFamily="@font/open_sans"
+        android:textSize="14sp"
+        android:layout_marginEnd="30dp"
+        />
+
+    <TextView
+        android:id="@+id/standard_sheet_confirm_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/standard_sheet_content"
+        tools:text="Confirm "
+        android:layout_marginTop="40dp"
+        android:textFontWeight="600"
+        android:textColor="@color/wa_white"
+        android:fontFamily="@font/open_sans"
+        android:textSize="14sp"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/shared-ui/src/main/res/values/colors.xml
+++ b/shared-ui/src/main/res/values/colors.xml
@@ -9,4 +9,5 @@
     <color name="wa_orange">#D6933B</color>
     <color name="wa_red_error">#CE1515</color>
     <color name="wa_grey">#E8E8EC</color>
+    <color name="black010101">#010101</color>
 </resources>

--- a/shared-ui/src/main/res/values/styles.xml
+++ b/shared-ui/src/main/res/values/styles.xml
@@ -12,4 +12,12 @@
         <item name="android:textSize">15sp</item>
     </style>
 
+    <style name="AppBottomSheetDialogTheme" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/CustomBottomSheetStyle</item>
+    </style>
+
+    <style name="CustomBottomSheetStyle" parent="Widget.Design.BottomSheet.Modal">
+        <item name="android:background">@drawable/drag_anchor_drawable</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Usage example for generic styles : 

`BottomSheetUtils.showStandardSheet(activity.supportFragmentManager,"Test",descriptionText = "Test description Test descriptionTest descriptionTest descriptionTest descriptionTest descriptionTest descriptionTest description",actionButtonLabel = "Confirm",cancelButtonLabel = "Cancel",onConfirmClick = {},onCancelClick = {} )
`
Or you can add your own custom design inside the `BottomSheetUtils` class.