### PR TITLE
Fix waiting forever for media metadata

### DIFF
--- a/mobile/src/main/java/rs/readahead/washington/mobile/util/C.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/util/C.java
@@ -29,6 +29,7 @@ public class C {
     public static final int IMPORT_MULTIPLE_FILES       = 10021;
     public static final int RECORD_REQUEST_CODE         = 10022;
     public static final int IMPORT_FILE                 = 10023;
+    public static final int LOCATION_PERMISSION         = 10024;
 
     // "global" intent keys
     public static final String CAPTURED_MEDIA_FILE_ID = "cmfi";

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/MetadataActivity.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/activity/MetadataActivity.java
@@ -63,7 +63,6 @@ import rs.readahead.washington.mobile.util.LocationUtil;
 import rs.readahead.washington.mobile.util.MetadataUtils;
 import rs.readahead.washington.mobile.util.TelephonyUtils;
 import rs.readahead.washington.mobile.views.base_ui.BaseLockActivity;
-import org.hzontal.shared_ui.bottomsheet.BottomSheetUtils;
 
 
 public abstract class MetadataActivity extends BaseLockActivity implements
@@ -461,7 +460,7 @@ public abstract class MetadataActivity extends BaseLockActivity implements
         }
 
         // if location gathering is not possible skip it
-        if (!isLocationProviderEnabled()) {
+        if (!isLocationProviderEnabled() || isFineLocationPermissionDenied()) {
             metadataAttacher.attachMetadata(vaultFile, metadata);
             return;
         }

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/settings/GeneralSettings.kt
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/settings/GeneralSettings.kt
@@ -1,17 +1,22 @@
 package rs.readahead.washington.mobile.views.settings
 
+import android.Manifest
+import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CompoundButton
 import android.widget.TextView
+import androidx.core.app.ActivityCompat
 import androidx.navigation.Navigation
 import org.hzontal.shared_ui.switches.TellaSwitchWithMessage
 import org.hzontal.shared_ui.utils.DialogUtils
 import rs.readahead.washington.mobile.R
 import rs.readahead.washington.mobile.data.sharedpref.Preferences
+import rs.readahead.washington.mobile.util.C.LOCATION_PERMISSION
 import rs.readahead.washington.mobile.util.CleanInsightUtils
 import rs.readahead.washington.mobile.util.LocaleManager
 import rs.readahead.washington.mobile.util.StringUtils
@@ -69,7 +74,12 @@ class GeneralSettings : BaseFragment() {
 
         val verificationSwitch = view.findViewById<TellaSwitchWithMessage>(R.id.verification_switch)
         verificationSwitch.mSwitch.setOnCheckedChangeListener { switch: CompoundButton?, isChecked: Boolean ->
-            Preferences.setAnonymousMode(!isChecked)
+            run {
+                if (!context?.let { hasLocationPermission(it) }!!){
+                    requestLocationPermission(LOCATION_PERMISSION)
+                }
+                Preferences.setAnonymousMode(!isChecked)
+            }
         }
         verificationSwitch.mSwitch.isChecked = !Preferences.isAnonymousMode()
 
@@ -128,6 +138,24 @@ class GeneralSettings : BaseFragment() {
             requireActivity(),
             String.format(getString(R.string.clean_insights_signed_for_days)),
             false
+        )
+    }
+
+    fun hasLocationPermission(context: Context): Boolean {
+        if (ActivityCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+            return true
+        return false
+    }
+
+    fun requestLocationPermission(requestCode: Int) {
+        requestPermissions(
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ), requestCode
         )
     }
 }


### PR DESCRIPTION
T711 - Never-ending verification info gathering:
- Don't wait forever for metadata if the device's location is on and the app has no location permission.
- Ask permission to use the location when the user turns on the verification mode

