### PR TITLE
Reports fixes

### DIFF
--- a/mobile/src/main/java/rs/readahead/washington/mobile/data/database/DataSource.java
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/data/database/DataSource.java
@@ -2668,7 +2668,8 @@ public class DataSource implements IServersRepository, ITellaUploadServersReposi
                 EntityStatus.SUBMISSION_PENDING,
                 EntityStatus.SUBMISSION_PARTIAL_PARTS,
                 EntityStatus.SUBMISSION_IN_PROGRESS,
-                EntityStatus.SCHEDULED
+                EntityStatus.SCHEDULED,
+                EntityStatus.PAUSED
         });
     }
 

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/dialog/reports/edit/EditTellaServerFragment.kt
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/dialog/reports/edit/EditTellaServerFragment.kt
@@ -60,7 +60,7 @@ class EditTellaServerFragment :
                 val text = if (isAutoUploadActivated && !reportServer.isAutoUpload) {
                     R.string.Setting_Reports_Background_Upload_Disabled_Description
                 } else {
-                    R.string.Setting_Reports_Background_Upload_Description
+                    R.string.Setting_Reports_Auto_Report_Description
                 }
                 setExplainText(text)
             }

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/fragment/reports/entry/ReportsEntryFragment.kt
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/fragment/reports/entry/ReportsEntryFragment.kt
@@ -100,6 +100,7 @@ class ReportsEntryFragment :
             putFiles(viewModel.mediaFilesToVaultFiles(instance.widgetMediaFiles))
             isNewDraft = false
         }
+        highLightButtonsInit()
         checkIsNewDraftEntry()
         highLightSubmitButton()
         highLightButtonOutBoxButton()
@@ -150,14 +151,26 @@ class ReportsEntryFragment :
         )
     }
 
+    private fun highLightButtonsInit() {
+        binding?.reportTitleEt?.let { title ->
+            isTitleEnabled = title.length() > 0
+        }
+
+        binding?.reportDescriptionEt?.let { description ->
+            isDescriptionEnabled = description.length() > 0
+        }
+    }
+
     private fun highLightSubmitButton() {
         binding?.reportTitleEt?.onChange { title ->
-            isTitleEnabled = title.length > 1
+            isTitleEnabled = title.length > 0
             highLightDraftButton(isTitleEnabled)
+            highLightButtonOutBoxButton()
         }
 
         binding?.reportDescriptionEt?.onChange { description ->
-            isDescriptionEnabled = description.length > 1
+            isDescriptionEnabled = description.length > 0
+            highLightDraftButton(isTitleEnabled)
             highLightButtonOutBoxButton()
         }
 

--- a/mobile/src/main/java/rs/readahead/washington/mobile/views/fragment/reports/entry/ReportsEntryFragment.kt
+++ b/mobile/src/main/java/rs/readahead/washington/mobile/views/fragment/reports/entry/ReportsEntryFragment.kt
@@ -57,7 +57,7 @@ class ReportsEntryFragment :
         ReportsFilesRecyclerViewAdapter(this)
     }
     private lateinit var selectedServer: TellaReportServer
-    private var servers: ArrayList<TellaReportServer>? = null
+    private lateinit var servers: ArrayList<TellaReportServer>
     private var reportInstance: ReportInstance? = null
     private var isNewDraft = true
     private var isTitleEnabled = false
@@ -213,9 +213,12 @@ class ReportsEntryFragment :
     }
 
     private fun showSubmitReportErrorSnackBar() {
+        val errorRes =
+            if (servers.size > 1) R.string.Snackbar_Submit_Report_WithProject_Error else R.string.Snackbar_Submit_Report_Error
+
         DialogUtils.showBottomMessage(
             baseActivity,
-            getString(R.string.Snackbar_Submit_Report_Error),
+            getString(errorRes),
             false
         )
     }
@@ -263,9 +266,9 @@ class ReportsEntryFragment :
         with(viewModel) {
             listServers()
             serversList.observe(viewLifecycleOwner) { serversList ->
+                servers = arrayListOf()
+                servers.addAll(serversList)
                 if (serversList.size > 1) {
-                    servers = arrayListOf()
-                    servers?.addAll(serversList)
                     val listDropDown = mutableListOf<DropDownItem>()
                     serversList.map { server ->
                         listDropDown.add(DropDownItem(server.projectId, server.projectName))
@@ -277,7 +280,7 @@ class ReportsEntryFragment :
                         baseActivity
                     )
                     this@ReportsEntryFragment.reportInstance?.let {
-                        servers?.first { server -> server.id == it.serverId }?.let {
+                        servers.first { server -> server.id == it.serverId }.let {
                             selectedServer = it
                             binding?.serversDropdown?.setDefaultName(it.name)
                         }
@@ -434,7 +437,7 @@ class ReportsEntryFragment :
 
     override fun onDropDownItemClicked(position: Int, chosenItem: DropDownItem) {
         binding?.serversDropdown?.setDefaultName(chosenItem.name)
-        servers?.get(position)?.let {
+        servers.get(position).let {
             selectedServer = it
         }
     }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -788,5 +788,5 @@ button to add a new template.</string>
 
     <string name="settings.sec_keep.exif_switch" translatable="false">Preserve metadata when importing</string>
     <string name="settings.sec_keep.exif_expl" translatable="false">Retain EXIF metadata when importing photos and videos into Tella. This includes data about when the image was created, camera settings, location and your device.</string>
-
+    <string name="Snackbar_Submit_Report_WithProject_Error">To submit a report, please select a project, type in a title and either add a description or attach a file.</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -707,11 +707,9 @@ button to add a new template.</string>
     <string name="Setting_Reports_Edit_Connection" >Edit connection</string>
     <string name="Setting_Reports_Connection_Name" >Connection name</string>
     <string name="Setting_Reports_Auto_Report" >Auto-report</string>
-
-
-    <string name="Setting_Reports_Auto_Report_Description" >Whenever you take a photo/video/audio\nrecording in Tella, a report will automatically be\ncreated with the file and uploaded to this project.</string>
+    <string name="Setting_Reports_Auto_Report_Description" >Whenever you take a photo/video/audio recording in Tella, a report will automatically be created with the file and uploaded to this project.</string>
     <string name="Setting_Reports_Auto_Delete" >Auto-delete</string>
-    <string name="Setting_Reports_Auto_Delete_Description" >Automatically delete files from your device once\nthey are uploaded to this project as a report.</string>
+    <string name="Setting_Reports_Auto_Delete_Description" >Automatically delete files from your device once they are uploaded to this project as a report.</string>
     <string name="Setting_Reports_Settings_Completed" >Advanced settings complete</string>
     <string name="Setting_Reports_Settings_Completed_Description" >You can always change your Reports preferences in the Tella Settings.</string>
     <string name="Drafts_Reports_Empty_Message" >Your Drafts is currently empty. Reports that you have not submitted will appear here.</string>


### PR DESCRIPTION
T-And-1226 - Crash when connected to multiple reports - problem with required fields 
T-And-1228 - Problem with required fields for Edit Draft screen - cannot edit and submit a draft
T-And-1230 - Fix flow for exiting a report in the middle of submission
T-And-1178 -  Wrong text on the auto-report settings fields