### PR TITLE
T-And-1862: Ensure all files are submitted with auto-report on

### DIFF
--- a/mobile/src/main/java/org/horizontal/tella/mobile/data/database/DataSource.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/data/database/DataSource.java
@@ -1331,7 +1331,15 @@ public class DataSource implements IServersRepository, ITellaUploadServersReposi
         if (!instances.isEmpty()) {
             ReportInstance currentInstance = instances.get(0);
 
-            if (Util.currentTimestamp() - currentInstance.getUpdated() > C.UPLOAD_SET_DURATION) {
+            if (currentInstance.getStatus() == EntityStatus.SUBMISSION_IN_PROGRESS) {
+                // Don't modify an instance being actively uploaded — its in-memory file list in
+                // the worker would overwrite any changes we make here, destroying the new file.
+                // Create a fresh instance for this file instead; it will be uploaded by the
+                // next worker run (guaranteed by APPEND_OR_REPLACE WorkManager policy).
+                ReportInstance newReportInstance = ReportInstance.getAutoReportReportInstance(serverId, "Auto-report " + DateUtil.getDateTimeString());
+                newReportInstance.getWidgetMediaFiles().add(mediaFile);
+                reportInstance = dataBaseUtils.updateTellaReportsFormInstance(newReportInstance, D.T_REPORT_FORM_INSTANCE, D.T_REPORT_INSTANCE_VAULT_FILE);
+            } else if (Util.currentTimestamp() - currentInstance.getUpdated() > C.UPLOAD_SET_DURATION) {
                 currentInstance.setCurrent(0);
                 currentInstance.setStatus(EntityStatus.SUBMITTED);
                 currentInstance.setWidgetMediaFiles(getReportFiles(currentInstance, null));

--- a/mobile/src/main/java/org/horizontal/tella/mobile/domain/usecases/shared/ScheduleUploadReportFilesUseCase.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/domain/usecases/shared/ScheduleUploadReportFilesUseCase.kt
@@ -37,7 +37,11 @@ class ScheduleUploadReportFilesUseCase @Inject constructor(
                     .setConstraints(constraints)
                     .build()
 
-                // Schedule the upload report work using WorkManager
+                // APPEND_OR_REPLACE ensures a new worker is queued even when one is already running.
+                // Without this, files captured during an active upload would be silently dropped by
+                // WorkManager and never uploaded. This trades off strict 1-hour report grouping
+                // (files captured mid-upload go into a separate auto-report) for correctness.
+                // TODO: revisit if same-report grouping during active uploads becomes a requirement.
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     "WorkerUploadReport2",
                     ExistingWorkPolicy.APPEND_OR_REPLACE,

--- a/mobile/src/main/java/org/horizontal/tella/mobile/domain/usecases/shared/ScheduleUploadReportFilesUseCase.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/domain/usecases/shared/ScheduleUploadReportFilesUseCase.kt
@@ -40,7 +40,7 @@ class ScheduleUploadReportFilesUseCase @Inject constructor(
                 // Schedule the upload report work using WorkManager
                 WorkManager.getInstance(context).enqueueUniqueWork(
                     "WorkerUploadReport2",
-                    ExistingWorkPolicy.KEEP,
+                    ExistingWorkPolicy.APPEND_OR_REPLACE,
                     oneTimeJob
                 )
 

--- a/mobile/src/main/java/org/horizontal/tella/mobile/mvvm/viewmodel/TellaFileUploadSchedulerViewModel.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/mvvm/viewmodel/TellaFileUploadSchedulerViewModel.kt
@@ -56,6 +56,11 @@ class TellaFileUploadSchedulerViewModel @Inject constructor(val application: App
                     .setConstraints(constraints)
                     .build()
 
+                // APPEND_OR_REPLACE ensures a new worker is queued even when one is already running.
+                // Without this, files captured during an active upload would be silently dropped by
+                // WorkManager and never uploaded. This trades off strict 1-hour report grouping
+                // (files captured mid-upload go into a separate auto-report) for correctness.
+                // TODO: revisit if same-report grouping during active uploads becomes a requirement.
                 WorkManager.getInstance(application)
                 .enqueueUniqueWork("WorkerUploadReport2", ExistingWorkPolicy.APPEND_OR_REPLACE, oneTimeJob)
 

--- a/mobile/src/main/java/org/horizontal/tella/mobile/mvvm/viewmodel/TellaFileUploadSchedulerViewModel.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/mvvm/viewmodel/TellaFileUploadSchedulerViewModel.kt
@@ -57,7 +57,7 @@ class TellaFileUploadSchedulerViewModel @Inject constructor(val application: App
                     .build()
 
                 WorkManager.getInstance(application)
-                .enqueueUniqueWork("WorkerUploadReport2", ExistingWorkPolicy.KEEP, oneTimeJob)
+                .enqueueUniqueWork("WorkerUploadReport2", ExistingWorkPolicy.APPEND_OR_REPLACE, oneTimeJob)
 
                 MyApplication.getMainKeyHolder().timeout = LifecycleMainKey.NO_TIMEOUT
 


### PR DESCRIPTION
Pull requests should be opened against the `develop` branch. For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change

**Description:**
Change the behavior of the auto-report upload to ensure all files are submitted, which was not always happening before if several videos/pictures were captured in a short timespan. Specifically while a long video was being uploaded, we noticed that the following videos/pictures were not included in the same auto-report. 

By changing the KEEP policy with an APPEND_OR_REPLACE one, the aim is to ensure a new worker is queued even when one is already running for auto-reports. With the KEEP policy, the new request is dropped while the other is still running, and those files are never submitted to any report instance. With that change in place, along with the creation of a separate auto-report instance for the new files to be included in if there is a submission in progress, it mitigates the current issue.

Note: **This is a compromise solution**, because auto-report instances are expected to be reused for a longer period of time, but it was agreed that this behavior is better than missing file submissions along the way.

**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(Fixes an issue)*
- [ ] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------

Fixes T-And-1862 assana ticket (testing evidence attached in Assana)


## Proposed changes 
<!-- Describe the changes the PR makes. -->

* Change ExistingWorkPolicy type only for auto uploads
* Generate a new auto-report if one is being submitted 
*