### PR TITLE
fix: only display report has been uploaded message after the report f…

### DIFF
--- a/mobile/src/main/java/org/horizontal/tella/mobile/data/reports/repository/ReportsRepositoryImp.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/data/reports/repository/ReportsRepositoryImp.kt
@@ -54,6 +54,8 @@ import retrofit2.Response
 import timber.log.Timber
 import java.net.UnknownHostException
 import javax.inject.Inject
+import org.horizontal.tella.mobile.R
+import org.horizontal.tella.mobile.util.BottomMessageManager
 
 
 class ReportsRepositoryImp @Inject internal constructor(
@@ -239,10 +241,24 @@ class ReportsRepositoryImp @Inject internal constructor(
                 }
                 .subscribe({
                     handleInstanceStatus(instance, EntityStatus.DELETED)
+                    val stringRes = if (instance.widgetMediaFiles.all { it.mimeType?.startsWith("audio/") == true }) {
+                        R.string.Auto_Upload_Recording_Imported_Report_And_Deleted
+                    } else {
+                        R.string.Auto_Upload_Media_Imported_Report_And_Deleted
+                    }
+                    BottomMessageManager.emit(stringRes)
                 }, { throwable ->
                     throwable.printStackTrace()
                 })
 
+        } else if (instance.current == 1L) {
+            handleInstanceStatus(instance, EntityStatus.SUBMITTED)
+            val stringRes = if (instance.widgetMediaFiles.all { it.mimeType?.startsWith("audio/") == true }) {
+                R.string.Auto_Upload_Recording_Report
+            } else {
+                R.string.Auto_Upload_Media_Report
+            }
+            BottomMessageManager.emit(stringRes)
         } else {
             handleInstanceStatus(instance, EntityStatus.SUBMITTED)
         }

--- a/mobile/src/main/java/org/horizontal/tella/mobile/util/BottomMessageManager.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/util/BottomMessageManager.kt
@@ -1,0 +1,14 @@
+package org.horizontal.tella.mobile.util
+
+import androidx.annotation.StringRes
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+object BottomMessageManager {
+    private val _events = MutableSharedFlow<Int>(extraBufferCapacity = 1)
+    val events: SharedFlow<Int> = _events
+
+    fun emit(@StringRes stringRes: Int) {
+        _events.tryEmit(stringRes)
+    }
+}

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseActivity.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseActivity.kt
@@ -15,11 +15,17 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import org.hzontal.shared_ui.bottomsheet.BottomSheetUtils
+import org.hzontal.shared_ui.utils.DialogUtils
 import org.horizontal.tella.mobile.MyApplication
 import org.horizontal.tella.mobile.R
 import org.horizontal.tella.mobile.data.sharedpref.Preferences
+import org.horizontal.tella.mobile.util.BottomMessageManager
 import org.horizontal.tella.mobile.util.LocaleManager
 import org.horizontal.tella.mobile.util.LockTimeoutManager
 import org.horizontal.tella.mobile.util.ThemeStyleManager
@@ -35,6 +41,13 @@ abstract class BaseActivity : AppCompatActivity() {
     @Inject lateinit var divviupUtils : DivviupUtils
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                BottomMessageManager.events.collect { stringRes ->
+                    DialogUtils.showBottomMessage(this@BaseActivity, getString(stringRes), false)
+                }
+            }
+        }
         // Use Google-recommended API for edge-to-edge (avoids deprecated setStatusBarColor path)
         WindowCompat.enableEdgeToEdge(window)
         // Set window background to transparent so fragment backgrounds show through

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/recorder/MicActivity.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/recorder/MicActivity.kt
@@ -329,21 +329,6 @@ class MicActivity : MetadataActivity(),
         return this
     }
 
-    private fun onMediaFilesUploadScheduled() {
-        val isAutoUploadEnabled = Preferences.isAutoUploadEnabled()
-        val isAutoDeleteEnabled = Preferences.isAutoDeleteEnabled()
-
-        val message: String = if (isAutoUploadEnabled && isAutoDeleteEnabled) {
-            getString(R.string.Auto_Upload_Recording_Imported_Report_And_Deleted)
-        } else if (isAutoUploadEnabled) {
-            getString(R.string.Auto_Upload_Recording_Report)
-        } else {
-            return
-        }
-
-        DialogUtils.showBottomMessage(this, message, false)
-    }
-
     private fun onMediaFilesUploadScheduleError(throwable: Throwable?) {
     }
 

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/recorder/MicFragment.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/recorder/MicFragment.kt
@@ -377,21 +377,6 @@ class MicFragment : MetadataBaseLockFragment(),
         )
     }
 
-    private fun onMediaFilesUploadScheduled() {
-        val isAutoUploadEnabled = Preferences.isAutoUploadEnabled()
-        val isAutoDeleteEnabled = Preferences.isAutoDeleteEnabled()
-
-        val message: String = if (isAutoUploadEnabled && isAutoDeleteEnabled) {
-            getString(R.string.Auto_Upload_Recording_Imported_Report_And_Deleted)
-        } else if (isAutoUploadEnabled) {
-            getString(R.string.Auto_Upload_Recording_Report)
-        } else {
-            return
-        }
-
-        DialogUtils.showBottomMessage(metadataActivity, message, false)
-    }
-
     private fun onMediaFilesUploadScheduleError(throwable: Throwable?) {
     }
 

--- a/mobile/src/playstore/java/org/horizontal/tella/mobile/views/activity/camera/CameraActivity.kt
+++ b/mobile/src/playstore/java/org/horizontal/tella/mobile/views/activity/camera/CameraActivity.kt
@@ -161,7 +161,6 @@ class CameraActivity : MetadataActivity(), IMetadataAttachPresenterContract.IVie
         viewModel.lastMediaFileSuccess.observe(this) { mediaFile -> onLastMediaFileSuccess(mediaFile) }
         viewModel.lastMediaFileError.observe(this) { throwable -> onLastMediaFileError(throwable) }
         viewModel.rotationUpdate.observe(this) { rotation -> rotateViews(rotation) }
-        uploadViewModel.mediaFilesUploadScheduled.observe(this) { onMediaFilesUploadScheduled() }
         uploadViewModel.mediaFilesUploadScheduleError.observe(this) { onMediaFilesUploadScheduleError() }
     }
 
@@ -323,19 +322,6 @@ class CameraActivity : MetadataActivity(), IMetadataAttachPresenterContract.IVie
     }
 
     override fun getContext(): Context = this
-
-    private fun onMediaFilesUploadScheduled() {
-        val isAutoUploadEnabled = Preferences.isAutoUploadEnabled()
-        val isAutoDeleteEnabled = Preferences.isAutoDeleteEnabled()
-        val message = if (isAutoUploadEnabled && isAutoDeleteEnabled) {
-            getString(R.string.Auto_Upload_Media_Imported_Report_And_Deleted)
-        } else if (isAutoUploadEnabled) {
-            getString(R.string.Auto_Upload_Media_Report)
-        } else {
-            return
-        }
-        DialogUtils.showBottomMessage(this, message, false)
-    }
 
     private fun onMediaFilesUploadScheduleError() {}
 


### PR DESCRIPTION
Pull requests should be opened against the `develop` branch. For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change

**Description:**
- Display "Your report has been uploaded to the server" and "Your report has been uploaded to server and deleted" messages only after the report upload finishes and the files and report are deleted

**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(Fixes an issue)*
- [ ] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------

[Fixes T-And-1860 - Only show the "Your report has been upload to the server"  info sheet (the white one) when the report has been submitted, not when it's queued ](https://app.asana.com/1/1155076882573518/project/1199579928442791/task/1213728610368528)


## Proposed changes 
<!-- Describe the changes the PR makes. -->

* Display "Your report has been uploaded to the server" and "Your report has been uploaded to server and deleted" messages only after the report upload finishes and the files and report are deleted

#### When uploading multiple images in the same autoreport the message is displayed each time the report finishes uploading
https://github.com/user-attachments/assets/e55df4ec-3563-4e87-891c-953c34f853bd

#### When uploading a video and a recording with auto report and auto delete on the message is displayed after the report finishes uploading and deleting.
https://github.com/user-attachments/assets/498447e8-ab67-4146-b724-9dd84d3a2bcc

https://github.com/user-attachments/assets/b450b952-f32b-4999-b501-5d1c7fb5c1dc



