### PR TITLE
Enhances lock mechanism and centralizes unlock flow

### DIFF
--- a/mobile/src/main/java/org/horizontal/tella/mobile/MyApplication.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/MyApplication.java
@@ -57,6 +57,7 @@ import java.security.Security;
 import java.util.Arrays;
 
 import javax.inject.Inject;
+
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
@@ -80,6 +81,7 @@ import org.horizontal.tella.mobile.util.divviup.DivviupUtils;
 import org.horizontal.tella.mobile.views.activity.ExitActivity;
 import org.horizontal.tella.mobile.views.activity.MainActivity;
 import org.horizontal.tella.mobile.views.activity.onboarding.OnBoardingActivity;
+import org.horizontal.tella.mobile.views.base_ui.BaseLockActivity;
 
 import timber.log.Timber;
 
@@ -323,6 +325,11 @@ public class MyApplication extends MultiDexApplication implements IUnlockRegistr
         android.content.Intent intent = new android.content.Intent(context, org.horizontal.tella.mobile.views.activity.LockUpdateSuccessActivity.class);
         intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(intent);
+    }
+
+    @Override
+    public void launchFullAppUnlock(Activity activity) {
+        BaseLockActivity.launchFullAppUnlock(activity);
     }
 
     @Override

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseLockActivity.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseLockActivity.kt
@@ -11,6 +11,7 @@ import com.hzontal.tella_locking_ui.ui.pattern.PatternSetActivity
 import com.hzontal.tella_locking_ui.ui.pattern.PatternUnlockActivity
 import com.hzontal.tella_locking_ui.ui.pin.PinUnlockActivity
 import com.hzontal.tella_locking_ui.ui.pin.calculator.CalculatorActivity
+import android.app.Activity
 import info.guardianproject.cacheword.SecretsManager
 import org.hzontal.shared_ui.utils.CALCULATOR_THEME
 import org.hzontal.tella.keys.config.IUnlockRegistryHolder
@@ -22,6 +23,46 @@ import org.horizontal.tella.mobile.util.LockTimeoutManager.IMMEDIATE_SHUTDOWN
 import org.horizontal.tella.mobile.views.activity.PatternUpgradeActivity
 
 abstract class BaseLockActivity : BaseActivity() {
+
+    companion object {
+
+        /**
+         * Same unlock entry as [restrictActivity] when the key is stored but not in memory:
+         * no Settings / change-lock extras — user must unlock the app normally.
+         */
+        @JvmStatic
+        fun launchFullAppUnlock(activity: Activity) {
+            val holder = activity.applicationContext as IUnlockRegistryHolder
+            val intent = when (holder.unlockRegistry.getActiveMethod(activity)) {
+                UnlockRegistry.Method.TELLA_PIN -> {
+                    when (Preferences.getAppAlias()) {
+                        CALCULATOR_ALIAS, CALCULATOR_ALIAS_BLUE_SKIN, CALCULATOR_ALIAS_ORANGE_SKIN, CALCULATOR_ALIAS_YELLOW_SKIN
+                        -> Intent(activity, CalculatorActivity::class.java).putExtra(
+                            CALCULATOR_THEME,
+                            Preferences.getCalculatorTheme()
+                        )
+
+                        else -> Intent(activity, PinUnlockActivity::class.java)
+                    }
+                }
+
+                UnlockRegistry.Method.TELLA_PATTERN -> {
+                    Intent(activity, PatternUnlockActivity::class.java)
+                }
+
+                UnlockRegistry.Method.TELLA_PASSWORD -> {
+                    Intent(activity, PasswordUnlockActivity::class.java)
+                }
+
+                else -> {
+                    Intent(activity, PatternUnlockActivity::class.java)
+                }
+            }
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            activity.startActivity(intent)
+            activity.finish()
+        }
+    }
 
     private val holder by lazy { applicationContext as IUnlockRegistryHolder }
     var isLocked = false
@@ -47,36 +88,7 @@ abstract class BaseLockActivity : BaseActivity() {
     }
 
     private fun startUnlockingMainKey() {
-        val intent = when (holder.unlockRegistry.getActiveMethod(this)) {
-            UnlockRegistry.Method.TELLA_PIN -> {
-                //temp switch
-                when (Preferences.getAppAlias()) {
-                    CALCULATOR_ALIAS, CALCULATOR_ALIAS_BLUE_SKIN, CALCULATOR_ALIAS_ORANGE_SKIN, CALCULATOR_ALIAS_YELLOW_SKIN
-                    -> Intent(this, CalculatorActivity::class.java).putExtra(
-                        CALCULATOR_THEME,
-                        Preferences.getCalculatorTheme()
-                    )
-
-                    else -> Intent(this, PinUnlockActivity::class.java)
-                }
-
-            }
-
-            UnlockRegistry.Method.TELLA_PATTERN -> {
-                Intent(this, PatternUnlockActivity::class.java)
-            }
-
-            UnlockRegistry.Method.TELLA_PASSWORD -> {
-                Intent(this, PasswordUnlockActivity::class.java)
-            }
-
-            else -> {
-                Intent(this, PatternUnlockActivity::class.java)
-            }
-        }
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
-        this.startActivity(intent)
-        finish()
+        launchFullAppUnlock(this)
     }
 
     override fun onResume() {

--- a/tella-keys/src/main/java/org/hzontal/tella/keys/config/UnlockRegistry.java
+++ b/tella-keys/src/main/java/org/hzontal/tella/keys/config/UnlockRegistry.java
@@ -71,6 +71,20 @@ public class UnlockRegistry {
         return configs.get(getActiveMethod(context));
     }
 
+    /**
+     * Config for a registered unlock method without reading or changing the active method preference.
+     * Use when re-wrapping the main key for a lock-type change: store with the target config first,
+     * then call {@link #setActiveMethod(Context, Method)} in {@code store} success.
+     */
+    @NonNull
+    public UnlockConfig getRegisteredConfig(@NonNull Method method) {
+        UnlockConfig config = configs.get(method);
+        if (config == null) {
+            throw new IllegalStateException("No UnlockConfig registered for " + method);
+        }
+        return config;
+    }
+
     public boolean isDeviceCredentialsEnabled(@NonNull Context context) {
         if (!isDeviceCredentialsAvailable()) {
             return false;

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/common/BaseActivity.kt
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/common/BaseActivity.kt
@@ -19,6 +19,7 @@ import com.hzontal.tella_locking_ui.ReturnActivity
 import com.hzontal.tella_locking_ui.TellaKeysUI
 import org.hzontal.tella.keys.config.UnlockConfig
 import org.hzontal.tella.keys.config.UnlockRegistry
+import org.hzontal.tella.keys.key.LifecycleMainKey
 import org.hzontal.tella.keys.key.MainKey
 import timber.log.Timber
 
@@ -109,10 +110,19 @@ open class BaseActivity : AppCompatActivity() {
         }
     }
 
-    protected fun generateOrGetMainKey(): MainKey {
+    /**
+     * @return null if the in-memory key was cleared while a new lock was being confirmed; full-app unlock was started.
+     */
+    protected fun generateOrGetMainKey(): MainKey? {
         return if (TellaKeysUI.getMainKeyStore().isStored) {
             isConfirmSettingsUpdate = true
-            TellaKeysUI.getMainKeyHolder().get()
+            val holder = TellaKeysUI.getMainKeyHolder()
+            return try {
+                holder.get()
+            } catch (e: LifecycleMainKey.MainKeyUnavailableException) {
+                TellaKeysUI.getCredentialsCallback().launchFullAppUnlock(this)
+                null
+            }
         } else {
             MainKey.generate()
         }

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/common/CredentialsCallback.java
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/common/CredentialsCallback.java
@@ -1,5 +1,6 @@
 package com.hzontal.tella_locking_ui.common;
 
+import android.app.Activity;
 import android.content.Context;
 
 public interface CredentialsCallback {
@@ -16,4 +17,11 @@ public interface CredentialsCallback {
     void onFailedAttempts(long num);
 
     void saveRemainingAttempts(long num);
+
+    /**
+     * Main key was cleared (e.g. lock timeout) while confirming a new lock — treat as full app lock.
+     * No Settings / change-lock flow; user unlocks like a cold resume.
+     */
+    default void launchFullAppUnlock(Activity activity) {
+    }
 }

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/password/ConfirmPasswordActivity.kt
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/password/ConfirmPasswordActivity.kt
@@ -24,12 +24,16 @@ class ConfirmPasswordActivity : BasePasswordActivity() {
     override fun onSuccessSetPassword(password: String) {
         if (password == mConfirmPassword) {
             val keySpec = PBEKeySpec(password.toCharArray())
-            TellaKeysUI.getUnlockRegistry().setActiveMethod(this@ConfirmPasswordActivity, UnlockRegistry.Method.TELLA_PASSWORD)
-            val config = TellaKeysUI.getUnlockRegistry().getActiveConfig(this@ConfirmPasswordActivity)
-            TellaKeysUI.getMainKeyStore().store(generateOrGetMainKey(), config.wrapper, keySpec, object : MainKeyStore.IMainKeyStoreCallback {
+            val config = TellaKeysUI.getUnlockRegistry()
+                .getRegisteredConfig(UnlockRegistry.Method.TELLA_PASSWORD)
+            val mainKey = generateOrGetMainKey() ?: return
+            TellaKeysUI.getMainKeyStore().store(mainKey, config.wrapper, keySpec, object : MainKeyStore.IMainKeyStoreCallback {
                 override fun onSuccess(mainKey: MainKey) {
                     Timber.d("** MainKey stored: %s **", mainKey)
-                    // here, we store MainKey in memory -> unlock the app
+                    TellaKeysUI.getUnlockRegistry().setActiveMethod(
+                        this@ConfirmPasswordActivity,
+                        UnlockRegistry.Method.TELLA_PASSWORD
+                    )
                     TellaKeysUI.getMainKeyHolder().set(mainKey)
                     onSuccessConfirmUnlock()
                 }

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/pattern/PatternSetConfirmActivity.kt
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/pattern/PatternSetConfirmActivity.kt
@@ -69,7 +69,8 @@ class PatternSetConfirmActivity : SetPatternActivity() {
         val keySpec = PBEKeySpec(mNewPassphrase.toCharArray())
         val config = TellaKeysUI.getUnlockRegistry().getActiveConfig(this@PatternSetConfirmActivity)
 
-        TellaKeysUI.getMainKeyStore().store(generateOrGetMainKey(), config.wrapper, keySpec, object : MainKeyStore.IMainKeyStoreCallback {
+        val mainKey = generateOrGetMainKey() ?: return
+        TellaKeysUI.getMainKeyStore().store(mainKey, config.wrapper, keySpec, object : MainKeyStore.IMainKeyStoreCallback {
             override fun onSuccess(mainKey: MainKey) {
                 Timber.d("** MainKey stored: %s **", mainKey.key)
                 // here, we store MainKey in memory -> unlock the app

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/pin/ConfirmPinActivity.kt
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/pin/ConfirmPinActivity.kt
@@ -24,12 +24,19 @@ class ConfirmPinActivity  : BasePinActivity() {
     override fun onSuccessSetPin(pin: String?) {
        if (mConfirmPin == pin) {
            val keySpec = PBEKeySpec(pin?.toCharArray())
-           TellaKeysUI.getUnlockRegistry().setActiveMethod(this@ConfirmPinActivity,UnlockRegistry.Method.TELLA_PIN)
-           val config = TellaKeysUI.getUnlockRegistry().getActiveConfig(this@ConfirmPinActivity)
-           TellaKeysUI.getMainKeyStore().store(generateOrGetMainKey(), config.wrapper, keySpec, object : MainKeyStore.IMainKeyStoreCallback {
+           // Use target method config without setActiveMethod first: prefs must still reflect the
+           // previous lock until store succeeds, otherwise process death can leave TELLA_PIN with a
+           // pattern-wrapped key (or inconsistent prefs).
+           val config =
+               TellaKeysUI.getUnlockRegistry().getRegisteredConfig(UnlockRegistry.Method.TELLA_PIN)
+           val mainKey = generateOrGetMainKey() ?: return
+           TellaKeysUI.getMainKeyStore().store(mainKey, config.wrapper, keySpec, object : MainKeyStore.IMainKeyStoreCallback {
                override fun onSuccess(mainKey: MainKey) {
                    Timber.d("** MainKey stored: %s **", mainKey)
-                   // here, we store MainKey in memory -> unlock the app
+                   TellaKeysUI.getUnlockRegistry().setActiveMethod(
+                       this@ConfirmPinActivity,
+                       UnlockRegistry.Method.TELLA_PIN
+                   )
                    TellaKeysUI.getMainKeyHolder().set(mainKey)
                    onSuccessConfirmUnlock()
                }

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/pin/base/BasePinActivity.kt
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/ui/pin/base/BasePinActivity.kt
@@ -50,7 +50,7 @@ abstract class BasePinActivity : BaseActivity(), PinLockListener, View.OnClickLi
         pinTopImageView = findViewById(R.id.pin_TopImg)
         pinLeftButton.text =
             getText(if (!isFromSettings) R.string.LockSelect_Action_Back else R.string.LockSelect_Action_Cancel)
-        root = findViewById<ConstraintLayout?>(R.id.root)
+        root = findViewById(R.id.root)
 
         initListeners()
     }

--- a/tella-locking-ui/src/main/res/layout/activity_password.xml
+++ b/tella-locking-ui/src/main/res/layout/activity_password.xml
@@ -21,6 +21,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         android:src="@drawable/icon_left"
+        android:background="@color/space_cadet"
         android:contentDescription="@string/action_go_back"
         android:paddingStart="15dp"
         android:paddingEnd="15dp"


### PR DESCRIPTION
Pull requests should be opened against the `develop` branch. For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change

**Description:**
This pull request significantly improves the robustness and reliability of the application's locking mechanism, particularly during changes to the unlock method. It centralizes the unlock navigation logic, fixes timing issues with setting active unlock methods, and introduces a more resilient way to handle main key availability during lock confirmations. Minor UI adjustments are also included.

**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(Fixes an issue)*
- [x] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------

Fixes #T-And-1858


## Proposed changes 


*   Centralizes application unlock navigation logic into a reusable method within `BaseLockActivity`.
*   Introduces `UnlockRegistry.getRegisteredConfig` to enable retrieving lock configurations without immediately updating the active unlock method preference, which prevents potential race conditions during lock type changes.
*   Corrects the timing for setting the active unlock method (PIN or password) to occur only after the new main key wrapper has been successfully stored, ensuring data consistency.
*   Adds robust handling for scenarios where the in-memory main key becomes unavailable (e.g., due to lock timeout) while a new lock method is being confirmed, initiating a full app unlock flow.
*   Implements a default `launchFullAppUnlock` method in `CredentialsCallback` to streamline the full app unlock process.
*   Includes minor UI and layout adjustments for improved user experience.