### PR TITLE
refactor: Extricate F-Droid APK post-processing into a standalone script

### DIFF
--- a/.github/workflows/build-fdroid-apk.yml
+++ b/.github/workflows/build-fdroid-apk.yml
@@ -10,7 +10,8 @@ on:
       verify_upstream_baseline:
         description: >
           After a release asset already exists, compare baseline.prof to a fresh
-          rebuild (same checks as fdroiddata). Leave disabled for normal builds.
+          rebuild after the same postbuild steps as fdroiddata (not raw Gradle
+          output). Leave disabled for normal builds.
         type: boolean
         default: false
   push:
@@ -60,7 +61,7 @@ jobs:
           path: reproducible-apk-tools
 
       - name: Make Gradle executable
-        run: chmod +x ./gradlew
+        run: chmod +x ./gradlew ./scripts/fdroid-postprocess-apk.sh
 
       - name: Set SOURCE_DATE_EPOCH from commit
         run: |
@@ -99,14 +100,8 @@ jobs:
 
       - name: Apply F-Droid postbuild fixes (match fdroiddata recipe)
         run: |
-          OUT=$(find mobile/build/outputs/apk/fdroid/release -maxdepth 1 -type f -name "mobile-fdroid-release-unsigned.apk" | head -n 1)
-          test -n "$OUT"
-          python3 reproducible-apk-tools/inplace-fix.py --page-size 16 sort-baseline "$OUT" --apk
-          python3 reproducible-apk-tools/inplace-fix.py --page-size 16 fix-pg-map-id "$OUT" '381d455'
-          python3 reproducible-apk-tools/inplace-fix.py --page-size 16 fix-newlines "$OUT" --from-crlf 'META-INF/services/*'
-          mv "$OUT" unaligned.apk
-          python3 reproducible-apk-tools/zipalign.py --page-size 16 --pad-like-apksigner --replace unaligned.apk "$OUT"
-          cp "$OUT" "mobile-release-Foss-${VERSION_CODE}-unsigned.apk"
+          ./scripts/fdroid-postprocess-apk.sh --copy-artifact \
+            "mobile-release-Foss-${VERSION_CODE}-unsigned.apk"
 
       - name: Upload unsigned APK artifact
         uses: actions/upload-artifact@v4
@@ -149,9 +144,12 @@ jobs:
 
           for i in 1 2 3 4 5 6 7 8 9 10; do
             ./gradlew :mobile:clean :mobile:assembleFdroidRelease -Pfdroid --no-daemon
+            ./scripts/fdroid-postprocess-apk.sh
             rm -rf local
             mkdir -p local
-            unzip -q -d local mobile/build/outputs/apk/fdroid/release/mobile-fdroid-release-unsigned.apk
+            OUT=$(find mobile/build/outputs/apk/fdroid/release -maxdepth 1 -type f -name "mobile-fdroid-release-unsigned.apk" | head -n 1)
+            test -n "$OUT"
+            unzip -q -d local "$OUT"
             LOCAL_HASH=$(sha256sum local/assets/dexopt/baseline.prof | cut -d ' ' -f1)
             echo "Local baseline.prof sha256 (attempt $i): $LOCAL_HASH"
             if [ "$LOCAL_HASH" = "$UPSTREAM_HASH" ]; then

--- a/scripts/fdroid-postprocess-apk.sh
+++ b/scripts/fdroid-postprocess-apk.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Apply the same reproducible-apk-tools steps as fdroiddata metadata (postbuild).
+# Run from repo root after :mobile:assembleFdroidRelease. Optional: copy artifact.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+RAT="${RAT_DIR:-$REPO_ROOT/reproducible-apk-tools}"
+if [[ ! -d "$RAT" ]]; then
+  echo "Error: reproducible-apk-tools not found at $RAT (set RAT_DIR or checkout beside repo)"
+  exit 1
+fi
+
+OUT="$(find mobile/build/outputs/apk/fdroid/release -maxdepth 1 -type f -name 'mobile-fdroid-release-unsigned.apk' | head -n 1)"
+if [[ -z "$OUT" ]]; then
+  echo "Error: mobile-fdroid-release-unsigned.apk not found under mobile/build/outputs/apk/fdroid/release"
+  exit 1
+fi
+
+python3 "$RAT/inplace-fix.py" --page-size 16 sort-baseline "$OUT" --apk
+python3 "$RAT/inplace-fix.py" --page-size 16 fix-pg-map-id "$OUT" '381d455'
+python3 "$RAT/inplace-fix.py" --page-size 16 fix-newlines "$OUT" --from-crlf 'META-INF/services/*'
+mv "$OUT" unaligned.apk
+python3 "$RAT/zipalign.py" --page-size 16 --pad-like-apksigner --replace unaligned.apk "$OUT"
+
+if [[ "${1:-}" == "--copy-artifact" && -n "${2:-}" ]]; then
+  cp "$OUT" "$2"
+fi


### PR DESCRIPTION
Moves the APK post-build fixes (reproducible-apk-tools) into a reusable script to ensure consistency between the main build process and the baseline profile verification job. This deduplicates the logic and simplifies the CI workflow configuration.
