### PR TITLE
Fixes broken import and delete original

### DIFF
--- a/mobile/src/main/java/org/horizontal/tella/mobile/media/MediaFileHandler.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/media/MediaFileHandler.java
@@ -110,7 +110,7 @@ public class MediaFileHandler {
     }
 
     public static void startSelectMediaActivity(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode) {
-        launchFilePicker(activity, type, extraMimeType, true, requestCode);
+        launchFilePicker(activity, type, extraMimeType, true, requestCode, false);
     }
 
     private static void launchFilePicker(
@@ -118,8 +118,30 @@ public class MediaFileHandler {
             @NonNull String type,
             @Nullable String[] extraMimeType,
             boolean allowMultiple,
-            int requestCode) {
+            int requestCode,
+            boolean deleteOriginal) {
         PackageManager pm = activity.getPackageManager();
+
+        if (deleteOriginal) {
+            Intent openDocument = new Intent(Intent.ACTION_OPEN_DOCUMENT)
+                    .setType(type)
+                    .addCategory(Intent.CATEGORY_OPENABLE)
+                    .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, allowMultiple)
+                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                            | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+            if (extraMimeType != null) {
+                openDocument.putExtra(Intent.EXTRA_MIME_TYPES, extraMimeType);
+            }
+            if (openDocument.resolveActivity(pm) != null) {
+                try {
+                    activity.startActivityForResult(openDocument, requestCode);
+                    return;
+                } catch (ActivityNotFoundException e) {
+                    Timber.d(e, "ACTION_OPEN_DOCUMENT failed for import-and-delete");
+                }
+            }
+        }
 
         Intent getContent = new Intent(Intent.ACTION_GET_CONTENT)
                 .setType(type)
@@ -925,12 +947,17 @@ public class MediaFileHandler {
     }
 
     public static void startImportFiles(Activity context, Boolean multipleFile, String type) {
+        startImportFiles(context, multipleFile, type, false);
+    }
+
+    public static void startImportFiles(Activity context, Boolean multipleFile, String type, boolean deleteOriginal) {
         launchFilePicker(
                 context,
                 type != null ? type : "*/*",
                 null,
                 Boolean.TRUE.equals(multipleFile),
-                C.IMPORT_MULTIPLE_FILES
+                C.IMPORT_MULTIPLE_FILES,
+                deleteOriginal
         );
     }
 

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/attachements/AttachmentsFragment.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/attachements/AttachmentsFragment.kt
@@ -3,12 +3,16 @@ package org.horizontal.tella.mobile.views.fragment.vault.attachements
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.app.RecoverableSecurityException
 import android.app.ProgressDialog
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
+import android.provider.DocumentsContract
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -118,6 +122,14 @@ class AttachmentsFragment :
     private lateinit var gridLayoutManager: GridLayoutManager
     private var isLaunchingPicker = false
     private var lastTreeUri: Uri? = null
+
+    private val deleteImportedSourceLauncher = registerForActivityResult(
+        ActivityResultContracts.StartIntentSenderForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            uriToDelete?.let { deleteFileFromExternalStorage(it, afterConsent = true) }
+        }
+    }
 
     private val openTree = registerForActivityResult(
         androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree()
@@ -420,7 +432,7 @@ class AttachmentsFragment :
                 importAndDelete = true
                 baseActivity.maybeChangeTemporaryTimeout {
                     MediaFileHandler.startImportFiles(
-                        baseActivity, true, getCurrentType(filterType)
+                        baseActivity, true, getCurrentType(filterType), true
                     )
                 }
             }
@@ -845,13 +857,8 @@ class AttachmentsFragment :
     }
 
     private fun onMediaImportedWithDelete(uri: Uri) {
-        lifecycleScope.launch {
-            uri.let {
-                deleteFileFromExternalStorage(it)
-                uriToDelete = it
-            }
-        }
-
+        uriToDelete = uri
+        deleteFileFromExternalStorage(uri)
         onMediaFilesAdded()
     }
 
@@ -1150,6 +1157,15 @@ class AttachmentsFragment :
                     listVaultFilesUris.add(returnedUri)
                 }
             }
+            if (importAndDelete) {
+                val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                listVaultFilesUris.forEach { uri ->
+                    try {
+                        baseActivity.contentResolver.takePersistableUriPermission(uri, flags)
+                    } catch (_: SecurityException) {
+                    }
+                }
+            }
             viewModel.importVaultFiles(
                 listVaultFilesUris, currentRootID, importAndDelete
             )
@@ -1265,13 +1281,24 @@ class AttachmentsFragment :
         }
     }
 
-    private fun deleteFileFromExternalStorage(uri: Uri) {
-        val fileToDelete = DocumentFile.fromSingleUri(baseActivity, uri)
+    private fun deleteFileFromExternalStorage(uri: Uri, afterConsent: Boolean = false) {
         try {
-            fileToDelete?.delete()
-        } catch (exn: java.lang.Exception) {
-            exn.printStackTrace()
+            if (DocumentsContract.deleteDocument(baseActivity.contentResolver, uri)) {
+                return
+            }
+        } catch (e: SecurityException) {
+            if (!afterConsent && SDK_INT >= Build.VERSION_CODES.Q) {
+                (e as? RecoverableSecurityException)?.let { recoverable ->
+                    deleteImportedSourceLauncher.launch(
+                        IntentSenderRequest.Builder(
+                            recoverable.userAction.actionIntent.intentSender
+                        ).build()
+                    )
+                    return
+                }
+            }
         }
+        DocumentFile.fromSingleUri(baseActivity, uri)?.delete()
     }
 
     private fun maybeShowUploadIcon(menu: Menu) {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/attachements/AttachmentsViewModel.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/attachements/AttachmentsViewModel.kt
@@ -245,12 +245,11 @@ class AttachmentsViewModel @Inject constructor(
     fun importVaultFiles(uris: List<Uri>, parentId: String?, deleteOriginal: Boolean) {
         if (uris.isEmpty()) return
 
-        var currentUri: Uri? = null
         var lastImportName: String? = null
         disposables.add(Flowable.fromIterable(uris).flatMap { uri ->
             MediaFileHandler.importVaultFileUri(getApplication(), uri, parentId).toFlowable()
+                .map { vaultFile -> vaultFile to uri }
                 .doOnSubscribe {
-                    currentUri = uri
                     val file = MediaFileHandler.getUriInfo(application, uri)
                     lastImportName = file.name
                     val backgroundVideoFile = BackgroundActivityModel(
@@ -269,11 +268,11 @@ class AttachmentsViewModel @Inject constructor(
                     )
                 }
         }.observeOn(AndroidSchedulers.mainThread()).subscribeOn(Schedulers.computation())
-            .observeOn(AndroidSchedulers.mainThread()).subscribe({ vaultFile ->
+            .observeOn(AndroidSchedulers.mainThread()).subscribe({ (vaultFile, uri) ->
                 handleAddSuccess(vaultFile, BackgroundActivityStatus.COMPLETED)
 
                 if (deleteOriginal) {
-                    currentUri?.let { uri -> _mediaImportedWithDelete.postValue(uri) }
+                    _mediaImportedWithDelete.postValue(uri)
                 } else {
                     _mediaImported.postValue(vaultFile)
                 }


### PR DESCRIPTION
Pull requests should be opened against the `develop` branch. For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change

**Description:**
The 'import and delete original' feature was failing, specifically on newer Android versions, due to stricter file access and deletion permissions. This update modifies the file selection and deletion process to ensure it functions correctly by adhering to modern Android security requirements.

**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(Fixes an issue)*
- [ ] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------

Fixes #T-And-1941


## Proposed changes 


*   Updates the file picker to leverage `ACTION_OPEN_DOCUMENT` for import-and-delete operations, ensuring appropriate write permissions are granted.
*   Adds handling for `RecoverableSecurityException` on Android Q (API 29) and above, prompting users for consent to delete original imported files.
*   Acquires persistable URI permissions for imported files to maintain necessary write access for subsequent deletion.
*   Refactors the file deletion logic to use `DocumentsContract.deleteDocument` where applicable, with a robust fallback mechanism.
*   Ensures the correct original URI is passed to the deletion process after a file is successfully imported into the vault.