### PR TITLE
Centralizes screen security management

### DIFF
--- a/mobile/src/main/java/org/horizontal/tella/mobile/data/sharedpref/Preferences.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/data/sharedpref/Preferences.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import org.hzontal.shared_ui.utils.CalculatorTheme;
+import org.hzontal.shared_ui.utils.ScreenSecurity;
 import org.joda.time.DateTime;
 
 import java.util.Date;
@@ -63,11 +64,11 @@ public class Preferences {
     }
 
     public static boolean isSecurityScreenEnabled() {
-        return getBoolean(SharedPrefs.SET_SECURITY_SCREEN, true);
+        return ScreenSecurity.isEnabled(sharedPrefs.getPref());
     }
 
     public static void setSecurityScreenEnabled(boolean value) {
-        setBoolean(SharedPrefs.SET_SECURITY_SCREEN, value);
+        setBoolean(ScreenSecurity.PREF_KEY, value);
     }
 
     public static boolean isFirstStart() {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/data/sharedpref/SharedPrefs.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/data/sharedpref/SharedPrefs.java
@@ -63,7 +63,6 @@ public class SharedPrefs {
     static final String MUTE_CAMERA_SHUTTER = "mute_camera_shutter";
     static final String SHUTTER_DND_PROMPT_DECLINED = "shutter_dnd_prompt_declined";
     static final String KEEP_EXIF = "keep_exif";
-    static final String SET_SECURITY_SCREEN = "set_security_screen";
     static final String SHOW_FAVORITE_FORMS = "show_favorite_forms";
     static final String SHOW_FAVORITE_TEMPLATES = "show_favorite_Templates";
     static final String SHOW_RECENT_FILES = "show_recent_files";

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseActivity.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseActivity.kt
@@ -7,7 +7,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
 import android.widget.Toast
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
@@ -23,6 +22,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.hzontal.shared_ui.bottomsheet.BottomSheetUtils
 import org.hzontal.shared_ui.utils.DialogUtils
+import org.hzontal.shared_ui.utils.ScreenSecurity
 import org.horizontal.tella.mobile.MyApplication
 import org.horizontal.tella.mobile.R
 import org.horizontal.tella.mobile.data.sharedpref.Preferences
@@ -203,20 +203,7 @@ abstract class BaseActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        maybeEnableSecurityScreen()
-    }
-
-    private fun maybeEnableSecurityScreen() {
-        if (Preferences.isSecurityScreenEnabled()) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        } else {
-            window.clearFlags(
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        }
+        ScreenSecurity.applyToWindow(window, this)
     }
 
     private fun showTimeOutChangeDialog(confirm: () -> Unit) {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseLockActivity.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseLockActivity.kt
@@ -1,7 +1,6 @@
 package org.horizontal.tella.mobile.views.base_ui
 
 import android.content.Intent
-import android.view.WindowManager
 import com.hzontal.tella_locking_ui.CALCULATOR_ALIAS
 import com.hzontal.tella_locking_ui.CALCULATOR_ALIAS_BLUE_SKIN
 import com.hzontal.tella_locking_ui.CALCULATOR_ALIAS_ORANGE_SKIN
@@ -94,7 +93,6 @@ abstract class BaseLockActivity : BaseActivity() {
     override fun onResume() {
         Preferences.setUnlockTime(System.currentTimeMillis())
         restrictActivity()
-        maybeEnableSecurityScreen()
         super.onResume()
     }
 
@@ -105,19 +103,6 @@ abstract class BaseLockActivity : BaseActivity() {
             Preferences.setTempTimeout(false)
             // Immediately set the lock timeout to shut down the application
             LockTimeoutManager().lockTimeout = IMMEDIATE_SHUTDOWN
-        }
-    }
-
-    private fun maybeEnableSecurityScreen() {
-        if (Preferences.isSecurityScreenEnabled()) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE,
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        } else {
-            window.clearFlags(
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
         }
     }
 

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/utils/ScreenSecurity.kt
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/utils/ScreenSecurity.kt
@@ -1,0 +1,39 @@
+package org.hzontal.shared_ui.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.view.Window
+import android.view.WindowManager
+
+object ScreenSecurity {
+    const val PREFS_NAME = "washington_shared_prefs"
+    const val PREF_KEY = "set_security_screen"
+    const val DEFAULT_ENABLED = true
+
+    @JvmStatic
+    fun isEnabled(context: Context): Boolean =
+        isEnabled(
+            context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        )
+
+    @JvmStatic
+    fun isEnabled(preferences: SharedPreferences): Boolean =
+        preferences.getBoolean(PREF_KEY, DEFAULT_ENABLED)
+
+    @JvmStatic
+    fun applyToWindow(window: Window, context: Context) {
+        applyToWindow(window, isEnabled(context))
+    }
+
+    @JvmStatic
+    fun applyToWindow(window: Window, enabled: Boolean) {
+        if (enabled) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+}

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/common/BaseActivity.kt
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/common/BaseActivity.kt
@@ -1,11 +1,8 @@
 package com.hzontal.tella_locking_ui.common
 
-import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -17,14 +14,12 @@ import com.hzontal.tella_locking_ui.R
 import com.hzontal.tella_locking_ui.RETURN_ACTIVITY
 import com.hzontal.tella_locking_ui.ReturnActivity
 import com.hzontal.tella_locking_ui.TellaKeysUI
+import org.hzontal.shared_ui.utils.ScreenSecurity
 import org.hzontal.tella.keys.config.UnlockConfig
 import org.hzontal.tella.keys.config.UnlockRegistry
 import org.hzontal.tella.keys.key.LifecycleMainKey
 import org.hzontal.tella.keys.key.MainKey
 import timber.log.Timber
-
-const val SET_SECURITY_SCREEN = "set_security_screen"
-private const val SHARED_PREFS_NAME = "washington_shared_prefs"
 
 open class BaseActivity : AppCompatActivity() {
     protected val isFromSettings by lazy { intent.getBooleanExtra(IS_FROM_SETTINGS, false) }
@@ -40,9 +35,6 @@ open class BaseActivity : AppCompatActivity() {
         Timber.d("** %s: %s **", javaClass, "onCreate()")
         super.onCreate(savedInstanceState)
         WindowCompat.enableEdgeToEdge(window)
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE
-        )
         overridePendingTransition(R.anim.`in`, R.anim.out)
     }
 
@@ -57,7 +49,7 @@ open class BaseActivity : AppCompatActivity() {
 
     override fun onResume() {
         Timber.d("** %s: %s **", javaClass, "onResume()")
-        maybeEnableSecurityScreen()
+        ScreenSecurity.applyToWindow(window, this)
         super.onResume()
     }
 
@@ -128,18 +120,4 @@ open class BaseActivity : AppCompatActivity() {
         }
     }
 
-    private fun maybeEnableSecurityScreen() {
-        if (getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE).getBoolean(
-                SET_SECURITY_SCREEN, false
-            )
-        ) {
-            window.setFlags(
-                WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE
-            )
-        } else {
-            window.clearFlags(
-                WindowManager.LayoutParams.FLAG_SECURE
-            )
-        }
-    }
 }


### PR DESCRIPTION
Pull requests should be opened against the `develop` branch. For more information on contributing to Tella source code, see the [Contributor Guidelines](contributing/contributor_guide.md).

## Type of change

**Description:**
Consolidates screen security logic into a shared utility, addressing inconsistencies in how `FLAG_SECURE` was applied across different activities. This refactoring ensures proper handling of the security screen, particularly in scenarios like the onboarding process where it might not have been correctly hidden previously.

**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(Fixes an issue)*
- [ ] New feature *(Adds functionality)*
- [ ] Documentation *(Fix to documentation)*

----------------------------------------------------------------------------------------

Fixes #T-And-1942


## Proposed changes 


*   Introduces a new `ScreenSecurity` utility class in `shared-ui` to manage the `WindowManager.LayoutParams.FLAG_SECURE` flag and its associated shared preference key.
*   Refactors `Preferences` and `SharedPrefs` in the `mobile` module to use the centralized `ScreenSecurity` utility for checking and setting the screen security preference.
*   Removes duplicated screen security logic from `BaseActivity` and `BaseLockActivity` in `mobile` and `tella-locking-ui`, replacing it with calls to the new `ScreenSecurity` utility for consistent application.