### PR TITLE
Enhances security and refines UI flowss 

### DIFF
--- a/mobile/src/main/java/org/horizontal/tella/mobile/media/MediaFileHandler.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/media/MediaFileHandler.java
@@ -110,7 +110,11 @@ public class MediaFileHandler {
     }
 
     public static void startSelectMediaActivity(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode) {
-        launchFilePicker(activity, type, extraMimeType, true, requestCode, false);
+        startSelectMediaActivity(activity, type, extraMimeType, requestCode, true);
+    }
+
+    public static void startSelectMediaActivity(Activity activity, @NonNull String type, @Nullable String[] extraMimeType, int requestCode, boolean allowMultiple) {
+        launchFilePicker(activity, type, extraMimeType, allowMultiple, requestCode, false);
     }
 
     private static void launchFilePicker(

--- a/mobile/src/main/java/org/horizontal/tella/mobile/util/DialogsUtil.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/util/DialogsUtil.java
@@ -1,6 +1,7 @@
 package org.horizontal.tella.mobile.util;
 
 import android.annotation.SuppressLint;
+import android.app.Dialog;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -28,9 +29,30 @@ import org.horizontal.tella.mobile.domain.entity.collect.CollectFormInstanceStat
 import org.horizontal.tella.mobile.domain.entity.ServerType;
 
 import org.horizontal.tella.mobile.views.custom.CameraPreviewAnonymousButton;
+import org.hzontal.shared_ui.utils.ScreenSecurity;
 
 
 public class DialogsUtil {
+
+    /**
+     * Per Android guidance (see AOSP SecureDialogActivity / issuetracker 143778149) the flag
+     * must be set before the dialog is shown, so callers must secure() before show().
+     */
+    private static <T extends Dialog> T secure(Context context, T dialog) {
+        ScreenSecurity.applyToDialog(dialog, context);
+        return dialog;
+    }
+
+    /**
+     * Builds the dialog, applies screen security to its window, then shows it. This guarantees
+     * FLAG_SECURE is set before the window surface is created.
+     */
+    private static AlertDialog showSecure(Context context, AlertDialog.Builder builder) {
+        AlertDialog dialog = builder.create();
+        secure(context, dialog);
+        dialog.show();
+        return dialog;
+    }
 
     static void showMessageOKCancel(Context context, String message, DialogInterface.OnClickListener okListener) {
         AlertDialog.Builder builder =
@@ -39,30 +61,28 @@ public class DialogsUtil {
         builder.setPositiveButton(R.string.action_ok, okListener);
         builder.setNegativeButton(R.string.action_cancel, null);
         builder.setCancelable(true);
-        builder.show();
+        showSecure(context, builder);
     }
 
     public static AlertDialog showMessageOKCancelWithTitle(Context context, String message, String title, String positiveButton, String negativeButton,
                                                            DialogInterface.OnClickListener okListener, DialogInterface.OnClickListener cancelListener) {
-        return new AlertDialog.Builder(context, R.style.PurpleBackgroundLightLettersDialogTheme)
+        return showSecure(context, new AlertDialog.Builder(context, R.style.PurpleBackgroundLightLettersDialogTheme)
                 .setMessage(message)
                 .setTitle(title)
                 .setPositiveButton(positiveButton, okListener)
                 .setNegativeButton(negativeButton, cancelListener)
-                .setCancelable(true)
-                .show();
+                .setCancelable(true));
     }
 
     public static AlertDialog showThreeOptionDialogWithTitle(Context context, String message, String title, String positiveButton, String neutralButton, String negativeButton,
                                                              DialogInterface.OnClickListener okListener, DialogInterface.OnClickListener neutralListener, DialogInterface.OnClickListener cancelListener) {
-        return new AlertDialog.Builder(context)
+        return showSecure(context, new AlertDialog.Builder(context)
                 .setMessage(message)
                 .setTitle(title)
                 .setPositiveButton(positiveButton, okListener)
                 .setNeutralButton(neutralButton, neutralListener)
                 .setNegativeButton(negativeButton, cancelListener)
-                .setCancelable(false)
-                .show();
+                .setCancelable(false));
     }
 
     public static AlertDialog showDialog(
@@ -72,12 +92,11 @@ public class DialogsUtil {
             String negativeButton,
             DialogInterface.OnClickListener okListener,
             DialogInterface.OnClickListener cancelListener) {
-        return new AlertDialog.Builder(context, R.style.PurpleBackgroundLightLettersDialogTheme)
+        return showSecure(context, new AlertDialog.Builder(context, R.style.PurpleBackgroundLightLettersDialogTheme)
                 .setMessage(message)
                 .setPositiveButton(positiveButton, okListener)
                 .setNegativeButton(negativeButton, cancelListener)
-                .setCancelable(true)
-                .show();
+                .setCancelable(true));
     }
 
     public static ProgressDialog showLightProgressDialog(Context context, String text) {
@@ -85,6 +104,7 @@ public class DialogsUtil {
         dialog.setIndeterminate(true);
         dialog.setMessage(text);
         dialog.setCancelable(true);
+        secure(context, dialog);
         dialog.show();
         return dialog;
     }
@@ -94,6 +114,7 @@ public class DialogsUtil {
         dialog.setIndeterminate(true);
         dialog.setMessage(text);
         dialog.setCancelable(true);
+        secure(context, dialog);
         dialog.show();
         return dialog;
     }
@@ -118,6 +139,7 @@ public class DialogsUtil {
                 .setCancelable(true);
 
         final AlertDialog alertDialog = builder.create();
+        secure(context, alertDialog);
         alertDialog.show();
 
         return alertDialog;
@@ -150,6 +172,7 @@ public class DialogsUtil {
                 .setCancelable(true);
 
         final AlertDialog alertDialog = builder.create();
+        secure(context, alertDialog);
         alertDialog.show();
 
         return alertDialog;
@@ -201,6 +224,7 @@ public class DialogsUtil {
 
 
         final AlertDialog alertDialog = builder.create();
+        secure(context, alertDialog);
         alertDialog.show();
 
         return alertDialog;
@@ -222,6 +246,7 @@ public class DialogsUtil {
 
         final AlertDialog alertDialog = builder.create();
         alertDialog.setOnShowListener(arg0 -> alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setBackgroundColor(context.getResources().getColor(R.color.dark_purple)));
+        secure(context, alertDialog);
         alertDialog.show();
         alertDialog.getWindow().setBackgroundDrawable(context.getResources().getDrawable(R.drawable.purple_background));
 
@@ -243,6 +268,7 @@ public class DialogsUtil {
         final AlertDialog alertDialog = builder.create();
 
         alertDialog.setOnShowListener(arg0 -> alertDialog.getButton(AlertDialog.BUTTON_NEGATIVE).setBackgroundColor(context.getResources().getColor(R.color.dark_purple)));
+        secure(context, alertDialog);
         alertDialog.show();
         alertDialog.getWindow().setBackgroundDrawable(context.getResources().getDrawable(R.drawable.purple_background));
 
@@ -261,25 +287,23 @@ public class DialogsUtil {
             msgResId = R.string.collect_dialog_text_delete_draft_form;
         }
 
-        return new AlertDialog.Builder(context, R.style.PurpleBackgroundLightLettersDialogTheme)
+        return showSecure(context, new AlertDialog.Builder(context, R.style.PurpleBackgroundLightLettersDialogTheme)
                 .setMessage(msgResId)
                 .setPositiveButton(R.string.action_delete, listener)
                 .setNegativeButton(R.string.action_cancel, (dialog, which) -> {
                 })
-                .setCancelable(true)
-                .show();
+                .setCancelable(true));
     }
 
 
     public static AlertDialog showExportMediaDialog(@NonNull Context context, @NonNull DialogInterface.OnClickListener listener) {
-        return new AlertDialog.Builder(context)
+        return showSecure(context, new AlertDialog.Builder(context)
                 .setTitle(R.string.gallery_save_to_device_dialog_title)
                 .setMessage(R.string.gallery_save_to_device_dialog_expl)
                 .setPositiveButton(R.string.action_save, listener)
                 .setNegativeButton(R.string.action_cancel, (dialog, which) -> {
                 })
-                .setCancelable(true)
-                .show();
+                .setCancelable(true));
     }
 
     public interface autoUploadServerConsumer {
@@ -324,6 +348,7 @@ public class DialogsUtil {
             radioGroup.setOnCheckedChangeListener((group, checkedId) -> errorMessage.setVisibility(View.GONE));
         });
 
+        secure(context, alertDialog);
         alertDialog.show();
 
         return alertDialog;
@@ -367,6 +392,7 @@ public class DialogsUtil {
             radioGroup.setOnCheckedChangeListener((group, checkedId) -> errorMessage.setVisibility(View.GONE));
         });
 
+        secure(context, alertDialog);
         alertDialog.show();
 
         return alertDialog;

--- a/mobile/src/main/java/org/horizontal/tella/mobile/util/DialogsUtil.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/util/DialogsUtil.java
@@ -18,7 +18,6 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.horizontal.tella.mobile.R;
@@ -38,9 +37,8 @@ public class DialogsUtil {
      * Per Android guidance (see AOSP SecureDialogActivity / issuetracker 143778149) the flag
      * must be set before the dialog is shown, so callers must secure() before show().
      */
-    private static <T extends Dialog> T secure(Context context, T dialog) {
+    private static <T extends Dialog> void secure(Context context, T dialog) {
         ScreenSecurity.applyToDialog(dialog, context);
-        return dialog;
     }
 
     /**

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseActivity.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/base_ui/BaseActivity.kt
@@ -14,7 +14,9 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -41,8 +43,33 @@ abstract class BaseActivity : AppCompatActivity() {
     private lateinit var loading: View
     @Inject
     lateinit var divviupUtils: DivviupUtils
+
+    private val dialogScreenSecurityCallbacks =
+        object : FragmentManager.FragmentLifecycleCallbacks() {
+            override fun onFragmentViewCreated(
+                fm: FragmentManager,
+                f: Fragment,
+                v: View,
+                savedInstanceState: Bundle?
+            ) {
+                applyScreenSecurityIfDialog(f)
+            }
+
+            override fun onFragmentStarted(fm: FragmentManager, f: Fragment) {
+                applyScreenSecurityIfDialog(f)
+            }
+        }
+
+    private fun applyScreenSecurityIfDialog(fragment: Fragment) {
+        (fragment as? DialogFragment)?.dialog?.let {
+            ScreenSecurity.applyToDialog(it, this)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        supportFragmentManager.registerFragmentLifecycleCallbacks(dialogScreenSecurityCallbacks, true)
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 BottomMessageManager.events.collect { stringRes ->

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/collect/widgets/AudioWidget.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/collect/widgets/AudioWidget.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.reactivex.schedulers.Schedulers;
+import kotlin.Unit;
 import org.horizontal.tella.mobile.MyApplication;
 import org.horizontal.tella.mobile.R;
 import org.horizontal.tella.mobile.media.MediaFileHandler;
@@ -130,9 +131,12 @@ public class AudioWidget extends MediaFileBinaryWidget {
     }
 
     public void importAudio() {
-        Activity activity = (Activity) getContext();
-        FormController.getActive().setIndexWaitingForData(formEntryPrompt.getIndex());
-        MediaFileHandler.startSelectMediaActivity(activity, "audio/*", null, C.IMPORT_VIDEO);
+        BaseActivity activity = (BaseActivity) getContext();
+        activity.maybeChangeTemporaryTimeout(() -> {
+            FormController.getActive().setIndexWaitingForData(formEntryPrompt.getIndex());
+            MediaFileHandler.startSelectMediaActivity(activity, "audio/*", null, C.IMPORT_VIDEO, false);
+            return Unit.INSTANCE;
+        });
     }
 
     private void showPreview() {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/collect/widgets/DocMediaWidget.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/collect/widgets/DocMediaWidget.java
@@ -211,7 +211,8 @@ public class DocMediaWidget extends MediaFileBinaryWidget {
                     activity,
                     "*/*",  // No specific type, use MIME type filter
                     mimeTypes,
-                    C.IMPORT_FILE
+                    C.IMPORT_FILE,
+                    false
             );
 
             return Unit.INSTANCE;

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/collect/widgets/ImageWidget.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/collect/widgets/ImageWidget.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.reactivex.schedulers.Schedulers;
+import kotlin.Unit;
 import org.horizontal.tella.mobile.MyApplication;
 import org.horizontal.tella.mobile.R;
 import org.horizontal.tella.mobile.media.MediaFileHandler;
@@ -129,9 +130,12 @@ public class ImageWidget extends MediaFileBinaryWidget {
     }
 
     public void importPhoto() {
-        Activity activity = (Activity) getContext();
-        FormController.getActive().setIndexWaitingForData(formEntryPrompt.getIndex());
-        MediaFileHandler.startSelectMediaActivity(activity, "image/*", null, C.IMPORT_IMAGE);
+        BaseActivity activity = (BaseActivity) getContext();
+        activity.maybeChangeTemporaryTimeout(() -> {
+            FormController.getActive().setIndexWaitingForData(formEntryPrompt.getIndex());
+            MediaFileHandler.startSelectMediaActivity(activity, "image/*", null, C.IMPORT_IMAGE, false);
+            return Unit.INSTANCE;
+        });
     }
 
     private void showPreview() {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/collect/widgets/VideoWidget.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/collect/widgets/VideoWidget.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.reactivex.schedulers.Schedulers;
+import kotlin.Unit;
 import org.horizontal.tella.mobile.MyApplication;
 import org.horizontal.tella.mobile.R;
 import org.horizontal.tella.mobile.media.MediaFileHandler;
@@ -131,9 +132,12 @@ public class VideoWidget extends MediaFileBinaryWidget {
     }
 
     public void importVideo() {
-        Activity activity = (Activity) getContext();
-        FormController.getActive().setIndexWaitingForData(formEntryPrompt.getIndex());
-        MediaFileHandler.startSelectMediaActivity(activity, "video/mp4", null, C.IMPORT_VIDEO);
+        BaseActivity activity = (BaseActivity) getContext();
+        activity.maybeChangeTemporaryTimeout(() -> {
+            FormController.getActive().setIndexWaitingForData(formEntryPrompt.getIndex());
+            MediaFileHandler.startSelectMediaActivity(activity, "video/mp4", null, C.IMPORT_VIDEO, false);
+            return Unit.INSTANCE;
+        });
     }
 
     private void showPreview() {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/peertopeer/receipentflow/RecipientVerificationFragment.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/peertopeer/receipentflow/RecipientVerificationFragment.kt
@@ -139,6 +139,7 @@ class RecipientVerificationFragment :
             withContext(Dispatchers.IO) {
                 peerServerStarterManager.stopServer()
             }
+            viewModel.clearManualConnectionWaitingOnDiscard()
             navManager().navigateBackToStartNearBySharingFragmentAndClearBackStack()
         }
     }

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/peertopeer/senderflow/SenderManualConnectionFragment.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/peertopeer/senderflow/SenderManualConnectionFragment.kt
@@ -117,8 +117,13 @@ class SenderManualConnectionFragment :
 
     private fun isInputValid(): Boolean = with(binding) {
         ipAddressMask.isComplete &&
-                pin.text?.isNotBlank() == true &&
+                isPinValid() &&
                 port.text?.isNotBlank() == true
+    }
+
+    private fun isPinValid(): Boolean {
+        val pin = binding.pin.text?.toString().orEmpty()
+        return pin.length == 6 && pin.all { it.isDigit() }
     }
 
     private fun updateNextButtonState() = with(binding) {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/peertopeer/senderflow/SenderVerificationFragment.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/peertopeer/senderflow/SenderVerificationFragment.kt
@@ -80,10 +80,13 @@ class SenderVerificationFragment :
             viewModel.onUserTappedConfirmAndConnect()
         }
 
-        binding.discardBtn.setOnClickListener {
-            viewModel.clearManualConnectionWaitingOnDiscard()
-            navManager().navigateBackToStartNearBySharingFragmentAndClearBackStack()
-        }
+        binding.toolbar.backClickListener = { discardAndStartOver() }
+        binding.discardBtn.setOnClickListener { discardAndStartOver() }
+    }
+
+    private fun discardAndStartOver() {
+        viewModel.clearManualConnectionWaitingOnDiscard()
+        navManager().navigateBackToStartNearBySharingFragmentAndClearBackStack()
     }
 
     private fun initObservers() {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/peertopeer/viewmodel/PeerToPeerViewModel.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/peertopeer/viewmodel/PeerToPeerViewModel.kt
@@ -213,6 +213,7 @@ class PeerToPeerViewModel @Inject constructor(
         PeerEventManager.resetReceiverHashConfirmation()
         manualConnectionPinInvalid = false
         pinResetRequired = false
+        _waitingForOtherSide.postValue(false)
     }
 
     fun clearStaleManualConnectionWaitingState() {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/uwazi/attachments/AttachmentsActivitySelector.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/uwazi/attachments/AttachmentsActivitySelector.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.viewModels
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.GridLayoutManager
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
@@ -15,6 +16,7 @@ import com.hzontal.utils.MediaFile
 import dagger.hilt.android.AndroidEntryPoint
 import org.horizontal.tella.mobile.R
 import org.horizontal.tella.mobile.databinding.FragmentAttachmentsSelectorBinding
+import org.horizontal.tella.mobile.util.hide
 import org.horizontal.tella.mobile.util.setCheckDrawable
 import org.horizontal.tella.mobile.util.setMargins
 import org.horizontal.tella.mobile.views.activity.camera.CameraActivity
@@ -70,6 +72,9 @@ class AttachmentsActivitySelector : BaseActivity(), ISelectorVaultHandler, View.
             this@AttachmentsActivitySelector, this,
             gridLayoutManager, false, isMultiplePicker
         )
+
+        binding.checkBoxList.isVisible = !isMultiplePicker
+
         with(binding) {
 
             attachmentsRecyclerView.apply {
@@ -191,29 +196,26 @@ class AttachmentsActivitySelector : BaseActivity(), ISelectorVaultHandler, View.
 
     private fun updateAttachmentsToolbar(itemsSize: Int) {
         binding.toolbar.setToolbarNavigationIcon(R.drawable.ic_arrow_back_white_24dp)
-        if (itemsSize == 0) {
-            val titleRes = if (isListCheckOn) {
-                R.string.Vault_Select_Title
-            } else {
-                when (filterType) {
-                    FilterType.ALL -> R.string.Vault_AllFiles_Title
-                    FilterType.ALL_WITHOUT_DIRECTORY -> R.string.Vault_Files_Title
-                    FilterType.PHOTO -> R.string.Vault_Images_Title
-                    FilterType.VIDEO -> R.string.Vault_Videos_Title
-                    FilterType.AUDIO -> R.string.Vault_Audios_Title
-                    FilterType.DOCUMENTS -> R.string.Vault_Documents_Title
-                    FilterType.OTHERS -> R.string.Vault_Others_Title
-                    FilterType.PHOTO_VIDEO -> R.string.Vault_PhotosAndVideos_Title
-                    FilterType.AUDIO_VIDEO -> R.string.Vault_AllFiles_Title
-                    FilterType.PDF -> R.string.Vault_Documents_Title
-                }
+        val titleRes = if (isListCheckOn) {
+            R.string.Vault_Select_Title
+        } else {
+            when (filterType) {
+                FilterType.ALL -> R.string.Vault_AllFiles_Title
+                FilterType.ALL_WITHOUT_DIRECTORY -> R.string.Vault_Files_Title
+                FilterType.PHOTO -> R.string.Vault_Images_Title
+                FilterType.VIDEO -> R.string.Vault_Videos_Title
+                FilterType.AUDIO -> R.string.Vault_Audios_Title
+                FilterType.DOCUMENTS -> R.string.Vault_Documents_Title
+                FilterType.OTHERS -> R.string.Vault_Others_Title
+                FilterType.PHOTO_VIDEO -> R.string.Vault_PhotosAndVideos_Title
+                FilterType.AUDIO_VIDEO -> R.string.Vault_AllFiles_Title
+                FilterType.PDF -> R.string.Vault_Documents_Title
             }
-            binding.toolbar.setStartTextTitle(getString(titleRes))
+        }
+        binding.toolbar.setStartTextTitle(getString(titleRes))
+        if (itemsSize == 0) {
             binding.toolbar.setRightIcon(-1)
         } else {
-            binding.toolbar.setStartTextTitle(
-                attachmentsAdapter.selectedMediaFiles.size.toString() + " " + getString(R.string.Vault_Items)
-            )
             binding.toolbar.setRightIcon(R.drawable.ic_check_white)
             binding.toolbar.rightIconContentDescription = R.string.action_check
         }
@@ -260,21 +262,24 @@ class AttachmentsActivitySelector : BaseActivity(), ISelectorVaultHandler, View.
         updateAttachmentsToolbar(selected)
         val selectable = attachmentsAdapter.selectableNonDirectoryCount()
 
-        if (selectMode == SelectMode.SELECT_ALL && selected == 0) {
-            syncSelectionChromeLeavingSelectModeFully()
-            return
-        }
         if (selectable == 0) return
 
-        if (selectMode == SelectMode.SELECT_ALL && selected < selectable) {
+        if (selectMode == SelectMode.SELECT_ALL && selected == 0) {
+            // Stay in selection mode so taps keep toggling checkboxes (picker must not open files).
             selectMode = SelectMode.ONE_SELECTION
             bindSelectAllCheckbox(SelectAllCheckboxVisual.PARTIAL)
             return
         }
 
-        if (isListCheckOn && selectMode != SelectMode.SELECT_ALL && selected == selectable) {
+        if (selected == selectable) {
             selectMode = SelectMode.SELECT_ALL
             bindSelectAllCheckbox(SelectAllCheckboxVisual.ALL)
+            return
+        }
+
+        if (selectMode == SelectMode.SELECT_ALL && selected < selectable) {
+            selectMode = SelectMode.ONE_SELECTION
+            bindSelectAllCheckbox(SelectAllCheckboxVisual.PARTIAL)
         }
     }
 
@@ -287,14 +292,6 @@ class AttachmentsActivitySelector : BaseActivity(), ISelectorVaultHandler, View.
             SelectAllCheckboxVisual.ALL -> R.drawable.ic_check_box_on
         }
         binding.checkBoxList.setCheckDrawable(icon, this)
-    }
-
-    private fun syncSelectionChromeLeavingSelectModeFully() {
-        selectMode = SelectMode.DESELECT_ALL
-        isListCheckOn = false
-        attachmentsAdapter.enableSelectMode(false)
-        bindSelectAllCheckbox(SelectAllCheckboxVisual.IDLE)
-        updateAttachmentsToolbar(attachmentsAdapter.selectedMediaFiles.size)
     }
 
     private fun handleSelectMode() {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/uwazi/attachments/AttachmentsSelectorAdapter.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/uwazi/attachments/AttachmentsSelectorAdapter.java
@@ -113,6 +113,8 @@ public class AttachmentsSelectorAdapter extends RecyclerView.Adapter<Attachments
         } else {
             if (VaultFile.Type.fromValue(vaultFile.type.getValue()) == VaultFile.Type.DIRECTORY) {
                 holder.showFolderInfo();
+            } else {
+                holder.showDocumentInfo();
             }
         }
 

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/uwazi/widgets/UwaziImageWidget.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/uwazi/widgets/UwaziImageWidget.java
@@ -180,7 +180,7 @@ public class UwaziImageWidget extends UwaziFileBinaryWidget {
         BaseActivity activity = (BaseActivity) getContext();
         activity.maybeChangeTemporaryTimeout(() -> {
             waitingForAData = true;
-            MediaFileHandler.startSelectMediaActivity(activity, "image/*", null, C.IMPORT_IMAGE);
+            MediaFileHandler.startSelectMediaActivity(activity, "image/*", null, C.IMPORT_IMAGE, false);
             return Unit.INSTANCE;
         });
     }

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/uwazi/widgets/UwaziMediaWidget.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/uwazi/widgets/UwaziMediaWidget.java
@@ -170,7 +170,7 @@ public class UwaziMediaWidget extends UwaziFileBinaryWidget {
         BaseActivity activity = (BaseActivity) getContext();
         waitingForAData = true;
         activity.maybeChangeTemporaryTimeout(() -> {
-            MediaFileHandler.startSelectMediaActivity(activity,"video/*",null, C.IMPORT_VIDEO);
+            MediaFileHandler.startSelectMediaActivity(activity,"video/*",null, C.IMPORT_VIDEO, false);
             return Unit.INSTANCE;
         });
     }

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/adapters/VaultAdapter.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/adapters/VaultAdapter.kt
@@ -33,6 +33,9 @@ private const val ID_FILES_ACTIONS = "2"
 private const val ID_PANIC_MODE = "3"
 private const val ID_FILES_TITLE = "4"
 private const val ID_IMPROVEMENT = "5"
+const val ID_RECENT_FILES = "6"
+const val ID_FAVORITE_FORMS = "7"
+const val ID_FAVORITE_TEMPLATES = "8"
 
 class VaultAdapter(private val onClick: VaultClickListener) :
     androidx.recyclerview.widget.ListAdapter<DataItem, BaseViewHolder<*>>(

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/adapters/attachments/AttachmentsRecycleViewAdapter.java
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/adapters/attachments/AttachmentsRecycleViewAdapter.java
@@ -117,6 +117,8 @@ public class AttachmentsRecycleViewAdapter extends RecyclerView.Adapter<Attachme
         } else {
             if (VaultFile.Type.fromValue(vaultFile.type.getValue()) == VaultFile.Type.DIRECTORY) {
                 holder.showFolderInfo();
+            } else {
+                holder.showDocumentInfo();
             }
         }
 

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/adapters/attachments/RecentAttachmentViewHolder.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/adapters/attachments/RecentAttachmentViewHolder.kt
@@ -11,7 +11,6 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.hzontal.tella_vault.VaultFile
 import com.hzontal.utils.MediaFile.isAudioFileType
 import com.hzontal.utils.MediaFile.isImageFileType
-import com.hzontal.utils.MediaFile.isTextFileType
 import com.hzontal.utils.MediaFile.isVideoFileType
 import org.horizontal.tella.mobile.R
 import org.horizontal.tella.mobile.views.fragment.vault.adapters.VaultClickListener
@@ -37,8 +36,14 @@ class RecentAttachmentViewHolder(val view: View) : BaseViewHolder<VaultFile?>(vi
     }
 
     private fun icPreview(vaultFile: VaultFile) {
-        if (vaultFile.mimeType == null) return
         when {
+            vaultFile.mimeType == null -> {
+                if (vaultFile.type == VaultFile.Type.DIRECTORY) {
+                    icAttachmentImg.setBackgroundResource(R.drawable.ic_folder_24px)
+                } else {
+                    showDocumentInfo(vaultFile)
+                }
+            }
             isImageFileType(vaultFile.mimeType) -> {
                 previewImageView.loadImage(vaultFile.thumb, R.drawable.ic_gallery)
             }
@@ -49,7 +54,7 @@ class RecentAttachmentViewHolder(val view: View) : BaseViewHolder<VaultFile?>(vi
                 showVideoInfo()
                 previewImageView.loadImage(vaultFile.thumb, R.drawable.ic_video)
             }
-            isTextFileType(vaultFile.mimeType) -> {
+            else -> {
                 showDocumentInfo(vaultFile)
             }
         }

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/adapters/viewholders/data/DataItem.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/adapters/viewholders/data/DataItem.kt
@@ -4,6 +4,9 @@ import com.hzontal.tella_vault.VaultFile
 import org.horizontal.tella.mobile.domain.entity.collect.CollectForm
 import org.horizontal.tella.mobile.domain.entity.uwazi.UwaziTemplate
 import org.horizontal.tella.mobile.views.fragment.vault.adapters.ID_CONNECTIONS
+import org.horizontal.tella.mobile.views.fragment.vault.adapters.ID_FAVORITE_FORMS
+import org.horizontal.tella.mobile.views.fragment.vault.adapters.ID_FAVORITE_TEMPLATES
+import org.horizontal.tella.mobile.views.fragment.vault.adapters.ID_RECENT_FILES
 import org.horizontal.tella.mobile.views.fragment.vault.adapters.connections.ServerDataItem
 
 sealed class DataItem {
@@ -14,15 +17,15 @@ sealed class DataItem {
     }
 
     data class RecentFiles(val vaultFiles: List<VaultFile?>) : DataItem() {
-        override val id = vaultFiles[0]?.id.toString()
+        override val id = ID_RECENT_FILES
     }
 
     data class FavoriteForms(val forms: List<CollectForm>) : DataItem() {
-        override val id: String = forms[0].id.toString()
+        override val id: String = ID_FAVORITE_FORMS
     }
 
     data class FavoriteTemplates(val templates: List<UwaziTemplate>) : DataItem() {
-        override val id: String = templates[0].id.toString()
+        override val id: String = ID_FAVORITE_TEMPLATES
     }
 
     data class FileActions(val idActions: String) : DataItem() {

--- a/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/home/HomeVaultFragment.kt
+++ b/mobile/src/main/java/org/horizontal/tella/mobile/views/fragment/vault/home/HomeVaultFragment.kt
@@ -316,6 +316,8 @@ class HomeVaultFragment : BaseFragment(), VaultClickListener {
         vaultRecyclerView.apply {
             adapter = vaultAdapter
             layoutManager = LinearLayoutManager(baseActivity)
+            // Avoid insert/remove/move animations when home sections change (e.g. settings toggles).
+            itemAnimator = null
         }
         //Uncomment to add improvement section
         vaultAdapter.addAnalyticsBanner()
@@ -634,19 +636,9 @@ class HomeVaultFragment : BaseFragment(), VaultClickListener {
     }
 
     private fun maybeCountServers() {
-        clearServerCount()
+        // Refresh server counts in place; clearing connections first caused a visible
+        // flash when returning from settings (remove then re-add with animation).
         homeVaultViewModel.countAllServers()
-    }
-
-    private fun clearServerCount() {
-        googleDriveServersCounted = false
-        dropBoxServersCounted = false
-        nextCloudServersCounted = false
-        reportServersCounted = false
-        collectServersCounted = false
-        uwaziServersCounted = false
-        serversList?.clear()
-        vaultAdapter.removeConnectionServers()
     }
 
     private fun maybeClosePanic(): Boolean {
@@ -792,7 +784,6 @@ class HomeVaultFragment : BaseFragment(), VaultClickListener {
         } else {
             vaultAdapter.removeConnectionServers()
         }
-        scrollHomeToTop()
     }
 
     private fun handleServerCountsSuccess(serverCounts: ServerCounts) {

--- a/mobile/src/main/res/layout/sender_manual_connection.xml
+++ b/mobile/src/main/res/layout/sender_manual_connection.xml
@@ -114,6 +114,7 @@
                     android:imeOptions="actionNext"
                     android:importantForAutofill="no"
                     android:inputType="number"
+                    android:maxLength="6"
                     android:maxLines="1"
                     android:textColor="@color/wa_white"
                     android:textDirection="ltr"

--- a/mobile/src/main/res/layout/show_device_info_layout.xml
+++ b/mobile/src/main/res/layout/show_device_info_layout.xml
@@ -49,11 +49,11 @@
     <TextView
         android:id="@+id/titleDescTextView"
         style="@style/Tella_Main_White_Text.Meduim"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="24dp"
         android:layout_marginTop="24dp"
         android:gravity="center"
+        android:paddingHorizontal="@dimen/activity_horizontal_margin"
         android:text="@string/device_connection_instructions"
         android:textColor="@android:color/white"
         app:layout_constraintBottom_toTopOf="@+id/connectCode"

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -1068,7 +1068,7 @@ If you forget your lock, there is currently no way to recover it. Your data insi
   <string name="peerToPeer_documentation_url" translatable="false">https://tella-app.org/nearby-sharing/</string>
   <string name="enter_recipient_info">Enter the recipient’s device
 
- information to find it on the network.</string>
+ information to find it on the network</string>
   <string name="make_sure_sequence_matches">Make sure that this sequence matches what is shown on the sender’s device.</string>
   <string name="make_sure_sequence_matches_recipient">Make sure that this sequence matches what is shown on the recipient’s device.</string>
   <string name="discard_and_start_over">Discard and start over</string>

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/CustomBottomSheetFragment.kt
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/bottomsheet/CustomBottomSheetFragment.kt
@@ -20,6 +20,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.coroutines.launch
 import org.hzontal.shared_ui.R
+import org.hzontal.shared_ui.utils.ScreenSecurity
 import java.util.*
 
 open class CustomBottomSheetFragment : BottomSheetDialogFragment() {
@@ -259,6 +260,9 @@ open class CustomBottomSheetFragment : BottomSheetDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialog = super.onCreateDialog(savedInstanceState)
 
+        // The bottom sheet lives in its own window, so the activity's FLAG_SECURE does not
+        // apply to it. Set screen security explicitly on this dialog's window.
+        ScreenSecurity.applyToDialog(dialog, requireContext())
         dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         dialog.setOnShowListener {
             lifecycleScope.launch {

--- a/shared-ui/src/main/java/org/hzontal/shared_ui/utils/ScreenSecurity.kt
+++ b/shared-ui/src/main/java/org/hzontal/shared_ui/utils/ScreenSecurity.kt
@@ -1,5 +1,6 @@
 package org.hzontal.shared_ui.utils
 
+import android.app.Dialog
 import android.content.Context
 import android.content.SharedPreferences
 import android.view.Window
@@ -35,5 +36,15 @@ object ScreenSecurity {
         } else {
             window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
+    }
+
+    /**
+     * Applies the screen-security flag to a [Dialog]'s own window. Dialogs (including bottom
+     * sheets and alert dialogs) live in a window separate from the hosting activity, so the
+     * activity's FLAG_SECURE does not propagate to them and must be set explicitly.
+     */
+    @JvmStatic
+    fun applyToDialog(dialog: Dialog, context: Context) {
+        dialog.window?.let { applyToWindow(it, context) }
     }
 }

--- a/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/common/BaseActivity.kt
+++ b/tella-locking-ui/src/main/java/com/hzontal/tella_locking_ui/common/BaseActivity.kt
@@ -7,6 +7,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import com.hzontal.tella_locking_ui.IS_CAMOUFLAGE
 import com.hzontal.tella_locking_ui.IS_FROM_SETTINGS
 import com.hzontal.tella_locking_ui.IS_ONBOARD_LOCK_SET
@@ -31,9 +34,33 @@ open class BaseActivity : AppCompatActivity() {
     protected val registry: UnlockRegistry by lazy { TellaKeysUI.getUnlockRegistry() }
 
 
+    private val dialogScreenSecurityCallbacks =
+        object : FragmentManager.FragmentLifecycleCallbacks() {
+            override fun onFragmentViewCreated(
+                fm: FragmentManager,
+                f: Fragment,
+                v: View,
+                savedInstanceState: Bundle?
+            ) {
+                applyScreenSecurityIfDialog(f)
+            }
+
+            override fun onFragmentStarted(fm: FragmentManager, f: Fragment) {
+                applyScreenSecurityIfDialog(f)
+            }
+        }
+
+    private fun applyScreenSecurityIfDialog(fragment: Fragment) {
+        (fragment as? DialogFragment)?.dialog?.let {
+            ScreenSecurity.applyToDialog(it, this)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         Timber.d("** %s: %s **", javaClass, "onCreate()")
         super.onCreate(savedInstanceState)
+        // Dialogs/bottom sheets live in their own windows; apply screen security to each.
+        supportFragmentManager.registerFragmentLifecycleCallbacks(dialogScreenSecurityCallbacks, true)
         WindowCompat.enableEdgeToEdge(window)
         overridePendingTransition(R.anim.`in`, R.anim.out)
     }


### PR DESCRIPTION
This pull request introduces several improvements across the application, focusing on enhancing screen security, improving peer-to-peer manual connection stability, and refining media selection behavior.

*   **Improves Screen Security for Dialogs and Bottom Sheets**
    *   Ensures that `FLAG_SECURE` is consistently applied to all `AlertDialog`s, `ProgressDialog`s, `DialogFragment`s, and `BottomSheetDialogFragment`s. This prevents content from appearing in screenshots or screen recordings.

*   **Refines Peer-to-Peer Manual Connection Flow**
    *   Enforces a 6-digit numeric PIN for manual connections and updates the input field to reflect this.
    *   Correctly resets the "waiting for other side" state when a manual connection attempt is discarded.
    *   Standardizes the discard process for recipient and sender verification screens, ensuring consistent behavior when using the back button or discard action.

*   **Enforces Single File Selection in Forms**
    *   Updates various media and document picker widgets (audio, video, image, general files) to ensure only a single file can be selected when importing into forms.
    *   Adjusts the attachment selector UI to hide the multi-selection checkbox when not in multiple picker mode.

*   **Enhances Home Vault UI Stability**
    *   Disables item animations in the Home Vault recycler view to prevent visual glitches when sections update.
    *   Optimizes the refresh mechanism for connection server counts, avoiding flickering when returning from settings and ensuring the connections section remains at the top without requiring scroll.

*   **Other Minor UI Improvements**
    *   Includes small adjustments to text and layout in peer-to-peer connection screens.

Fixes T-And-1793, T-And-1970, T-And-1966, T-And-1962, T-And-1971,T-And-1944 